### PR TITLE
docs: self-contained code blocks + a test that enforces it

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Q(1, "bar").to("kPa")
 Q([1, 2, 3], "bar") * 2  # [2, 4, 6] bar
 
 # without a unit, the quantity is dimensionless
-Q(0.1) == Q(10, "%")
+assert Q(0.1) == Q(10, "%")
 ```
 
 ### `Quantity` type system
@@ -63,6 +63,8 @@ Common dimensionalities are defined in the `encomp.utypes` module.
 A newly created dimensionality gets a class name of the form `Dimensionality[...]` (for example `Quantity[Dimensionality[[mass] ** 2 / [length] ** 3]]`).
 
 ```python
+# test: no-run
+
 from encomp.units import Quantity as Q
 from encomp.utypes import MassFlow, Volume
 
@@ -107,6 +109,8 @@ The `Quantity` subtypes also restrict function and class attribute types at runt
 The `typeguard.typechecked` decorator checks function inputs and outputs:
 
 ```python
+# test: no-run
+
 from typing import Any, TypedDict
 
 from typeguard import typechecked
@@ -132,7 +136,7 @@ class OutputDict(TypedDict):
 
 
 @typechecked
-def another_func(s: Q[Length, Any]) -> OutputDict:
+def another_func(_s: Q[Length, Any]) -> OutputDict:
     return {"T": Q(25, "m"), "P": Q(25, "kPa")}
 
 
@@ -144,9 +148,11 @@ another_func(Q(25, "m"))
 To create a new dimensionality (for example temperature difference per mass flow rate), combine the `pint.UnitsContainer` objects stored in the `dimensions` class attribute.
 
 ```python
+import contextlib
+
 from encomp.units import DimensionalityError
 from encomp.units import Quantity as Q
-from encomp.utypes import Dimensionality, MassFlow, TemperatureDifference, Volume
+from encomp.utypes import Dimensionality, MassFlow, TemperatureDifference
 
 
 # the class name TemperaturePerMassFlow must be globally unique
@@ -158,10 +164,8 @@ class TemperaturePerMassFlow(Dimensionality):
 qty = Q(1, "delta_degC/(kg/s)").asdim(TemperaturePerMassFlow)
 
 # raises an exception since liter is Length**3 and the Quantity expects Mass
-try:
-    another_qty = Q(1, "delta_degC/(liter/hour)").asdim(TemperaturePerMassFlow)
-except DimensionalityError:
-    pass
+with contextlib.suppress(DimensionalityError):
+    Q(1, "delta_degC/(liter/hour)").asdim(TemperaturePerMassFlow)
 
 # create a new subclass of Quantity with restricted input units
 CustomCoolingCapacity = Q[TemperaturePerMassFlow, float]
@@ -189,7 +193,7 @@ from encomp.units import Quantity as Q
 air = Fluid("air", T=Q(25, "degC"), P=Q(2, "bar"))
 
 # common fluid properties have type hints, and show up using autocomplete
-air.D  # 2.338399526231983 kg/m³
+density = air.D  # 2.338399526231983 kg/m³
 
 air.search("density")
 # ['DELTA, Delta: Reduced density (rho/rhoc) [dimensionless]',
@@ -197,7 +201,7 @@ air.search("density")
 #  'D, DMASS, Dmass: Mass density [kg/m³]', ...
 
 # any of the names are valid attributes (case-sensitive)
-air.Dmolar  # 80.73061937328056 mol/m³
+molar_density = air.Dmolar  # 80.73061937328056 mol/m³
 ```
 
 The `Water` subclass (and `Fluid("IF97::Water")`) evaluates steam and water properties with *IAPWS-IF97* (Industrial Formulation 1997). For the *IAPWS-95* reference formulation, use the HEOS backend: `Fluid("HEOS::Water", ...)`; the bare name `Fluid("water", ...)` also resolves to HEOS.
@@ -223,6 +227,7 @@ Use `assume_phase` to skip CoolProp's phase-stability search when the phase is k
 
 ```python
 from encomp.fluids import Fluid
+from encomp.units import Quantity as Q
 
 # equivalent: fractions in the name, or a composition dict
 Fluid("HEOS::CO2[0.7]&O2[0.3]", P=Q(10, "bar"), T=Q(300, "K"))
@@ -287,7 +292,7 @@ Benchmarks (CoolProp 8.0, 14-thread pool):
 
 | workload | vs `map_batches` | notes |
 | --- | --- | --- |
-| single property `D`, 1,000,000 rows | ~2.1x | also ~2x faster than vectorized `PropsSI` |
+| single property `D`, 1M rows | ~2.1x | also ~2x faster than vectorized `PropsSI` |
 | 4 independent properties, one `collect()`, 1M rows | ~4.6x | `map_batches` is serial on the GIL; the plugin runs ~4 cores |
 | 8 enthalpy calculations, 1M rows | ~4.9x | ~6 cores vs 1, roughly half the peak memory |
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -11,15 +11,11 @@ Each dimensionality is a separate subclass, so static type checkers catch dimens
 `Q` is an alias for `Quantity`: `from encomp.units import Quantity as Q`
 :::
 
-Import the class:
+Import the class, then create an instance representing an absolute pressure of 1 bar:
 
 ```python
 from encomp.units import Quantity as Q
-```
 
-Create an instance representing an absolute pressure of 1 bar:
-
-```python
 pressure = Q(1, "bar")
 ```
 
@@ -30,8 +26,12 @@ pressure = Q(1, "bar")
 Convert the pressure to another unit:
 
 ```python
-# pressure_kPa is a new Quantity instance
-pressure_kPa = pressure.to("kPa")
+from encomp.units import Quantity as Q
+
+pressure = Q(1, "bar")
+
+# pressure_kpa is a new Quantity instance
+pressure_kpa = pressure.to("kPa")
 ```
 
 The unit definition file (`encomp/defs/units.txt`) lists the accepted unit names.
@@ -41,6 +41,7 @@ Quantities can also be constructed from unit registry attributes:
 
 ```python
 from encomp.units import UNIT_REGISTRY
+from encomp.units import Quantity as Q
 
 d = 50 * UNIT_REGISTRY.m
 v = d / UNIT_REGISTRY.s
@@ -54,12 +55,17 @@ Each dimensionality is a unique subclass of {py:class}`encomp.units.Quantity`.
 The base class itself cannot be instantiated, since it would have no dimensionality at all (a *dimensionless* quantity still has a dimensionality of *1*).
 
 ```python
+from encomp.units import Quantity as Q
+
+pressure = Q(1, "bar")
+pressure_kpa = pressure.to("kPa")
+
 type(pressure)  # <class 'encomp.units.Quantity[Pressure, float]'>
 
 fraction = Q(5, "%")
 type(fraction)  # <class 'encomp.units.Quantity[Dimensionless, float]'>
 
-assert type(pressure) is type(pressure_kPa)
+assert type(pressure) is type(pressure_kpa)
 
 length = Q(1, "meter")
 assert type(pressure) is not type(length)
@@ -75,11 +81,12 @@ The type parameter is the subclass itself, not an instance: `Q[Power]` works, `Q
 Subclasses for common dimensionalities are defined in {py:mod}`encomp.utypes`.
 
 ```python
+from encomp.units import Quantity as Q
 from encomp.utypes import Dimensionality, Length, Power, Pressure
 
 Q[Pressure, float]  # subclass with dimensionality pressure and magnitude float
 
-Pressure.dimensions  # <UnitsContainer({'[length]': -1, '[mass]': 1, '[time]': -2})>
+pressure_dims = Pressure.dimensions  # <UnitsContainer({'[length]': -1, '[mass]': 1, '[time]': -2})>
 
 
 # the class name PowerPerLength must be globally unique
@@ -94,6 +101,12 @@ Check the dimensionality of a quantity with `isinstance()` or {py:meth}`encomp.u
 For parameterized types like `list[Quantity[Pressure]]`, use {py:func}`encomp.misc.isinstance_types` instead of `isinstance()`.
 
 ```python
+from encomp.misc import isinstance_types
+from encomp.units import Quantity as Q
+from encomp.utypes import Length, Pressure
+
+pressure = Q(1, "bar")
+
 pressure.check(Length)  # False
 pressure.check("meter")  # False
 
@@ -108,8 +121,6 @@ isinstance(pressure, Q[Length])  # False
 # complex types must use isinstance_types
 # this function can also be used with simple types
 
-from encomp.misc import isinstance_types
-
 isinstance_types([pressure, pressure], list[Q[Pressure]])  # True
 isinstance_types({1: Q(2, "m"), 2: Q(25, "cm")}, dict[int, Q[Length]])  # True
 
@@ -120,11 +131,16 @@ isinstance_types(pressure, Q)  # True
 For functions and methods, use the `typeguard.typechecked` decorator instead of explicit checks in the function body:
 
 ```python
+# test: no-run
+
 from typeguard import typechecked
+
+from encomp.units import Quantity as Q
+from encomp.utypes import Length, Power, Pressure
 
 
 @typechecked
-def func(p1: Q[Pressure]) -> tuple[Q[Length], Q[Power]]:
+def func(_p1: Q[Pressure]) -> tuple[Q[Length], Q[Power]]:
     return Q(1, "m"), Q(1, "kW")
 ```
 
@@ -139,6 +155,7 @@ Additionally, the *normal* dimensionality (used to represent normal volume) and 
 If the dimensionality already exists, {py:class}`encomp.units.DimensionalityRedefinitionError` is raised.
 
 ```python
+from encomp.units import Quantity as Q
 from encomp.units import define_dimensionality
 
 define_dimensionality("dry_air")
@@ -146,11 +163,11 @@ define_dimensionality("oxygen")
 
 # the new dimensionality [dry_air] has a single unit: "dry_air"
 m_air = Q(5, "kg * dry_air")
-n_O2 = Q(2.4, "mol * oxygen")
+n_o2 = Q(2.4, "mol * oxygen")
 M_O2 = Q(32, "g/mol")
 
 # compute mass fraction
-((n_O2 * M_O2) / m_air).to_base_units()  # 0.01536 oxygen/dry_air
+((n_o2 * M_O2) / m_air).to_base_units()  # 0.01536 oxygen/dry_air
 ```
 
 ### Quantities with vector magnitudes
@@ -158,9 +175,11 @@ M_O2 = Q(32, "g/mol")
 Lists, Numpy arrays and Polars Series objects can also be used as magnitude.
 
 ```python
-type(Q([1, 2, 3], "kg").m)  # numpy.ndarray
-
 import numpy as np
+
+from encomp.units import Quantity as Q
+
+type(Q([1, 2, 3], "kg").m)  # numpy.ndarray
 
 arr = np.linspace(0, 1)
 Q(arr, "bar")
@@ -173,6 +192,8 @@ Polars Expressions can be used as magnitude:
 
 ```python
 import polars as pl
+
+from encomp.units import Quantity as Q
 
 type(Q(pl.lit(5), "kg").m)  # pl.Expr
 ```
@@ -188,6 +209,8 @@ Units do not always cancel out automatically.
 Call {py:meth}`encomp.units.Quantity.to_base_units` to simplify to base SI units, {py:meth}`encomp.units.Quantity.to` when the target unit is known, or {py:meth}`encomp.units.Quantity.to_reduced_units` to cancel units without converting to base SI units.
 
 ```python
+from encomp.units import Quantity as Q
+
 (Q(5, "%") * Q(1, "meter")).to("mm")  # 50.0 mm
 ```
 
@@ -196,10 +219,14 @@ A temperature *difference* in a degree scale is written with the prefix `delta_`
 Temperature ({py:class}`encomp.utypes.Temperature`) and temperature difference ({py:class}`encomp.utypes.TemperatureDifference`) are distinct dimensionalities and deliberately not interchangeable: a difference cannot silently be used as an absolute temperature.
 
 ```python
-dT = Q(5, "delta_degC")  # 5 Δ°C
+# test: no-run
+
+from encomp.units import Quantity as Q
+
+temp_diff = Q(5, "delta_degC")  # 5 Δ°C
 
 # this is not allowed
-dT.to("degC")
+temp_diff.to("degC")
 # DimensionalityTypeError: Cannot convert Δ°C (dimensionality TemperatureDifference)
 # to °C (dimensionality Temperature)
 
@@ -229,6 +256,8 @@ The dimensionality {py:class}`encomp.utypes.Currency` represents an arbitrary cu
 `SEK`, `EUR` and `USD` are defined by default.
 
 ```python
+from encomp.units import Quantity as Q
+
 mf = Q(25, "kg/s")
 t = Q(365, "d")
 
@@ -262,6 +291,8 @@ This error can also be imported from the {py:mod}`encomp.units` module.
 
 ```python
 from encomp.units import DimensionalityError
+from encomp.units import Quantity as Q
+from encomp.utypes import Pressure
 
 # alternatively, use pint.errors.DimensionalityError
 # from pint.errors import DimensionalityError
@@ -328,6 +359,8 @@ ratio=0.25
 `.py`-file:
 
 ```python
+# test: no-run
+
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from encomp.units import Quantity as Q
@@ -367,17 +400,21 @@ Not every combination of input parameters can fix the state: with an invalid inp
 An invalid property *name*, on the other hand, raises `ValueError`.
 
 ```python
+# test: no-run
+
 from encomp.fluids import Fluid
+from encomp.units import Quantity as Q
 
 Fluid("toluene", T=Q(25, "°C"), P=Q(2, "bar"))
 # <Fluid "toluene", P=200 kPa, T=25.0 °C, D=862.3 kg/m³, V=0.55 cP>
 
-# PCRIT cannot be used to fix the state
+# PCRIT cannot be used to fix the state (it is an output-only property,
+# not one of the FluidState inputs, so it is rejected statically too)
 invalid_inputs = Fluid("water", D=Q(500, "kg/m³"), PCRIT=Q(1, "bar"))
 # <Fluid "water", P=nan kPa, T=nan °C, D=nan kg/m³, V=nan cP>
 
 # every property is nan (CoolProp emits a warning about the invalid input pair)
-invalid_inputs.T  # nan °C
+temperature = invalid_inputs.T  # nan °C
 ```
 
 {py:class}`encomp.fluids.Water` omits the fluid name and uses `IAPWS-IF97` (Industrial Formulation 1997).
@@ -387,6 +424,7 @@ The {py:class}`encomp.fluids.HumidAir` class has a different set of input and ou
 
 ```python
 from encomp.fluids import HumidAir, Water
+from encomp.units import Quantity as Q
 
 # input units are converted to SI
 Water(P=Q(30, "psi"), T=Q(250, "°F"))
@@ -399,6 +437,11 @@ HumidAir(T=Q(25, "°C"), P=Q(2, "bar"), R=Q(25, "%"))
 Property names must match CoolProp's exactly:
 
 ```python
+# test: no-run
+
+from encomp.fluids import HumidAir
+from encomp.units import Quantity as Q
+
 HumidAir(T=Q(25, "°C"), Ps=Q(2, "bar"), R=Q(25, "%"))
 # ValueError: Invalid CoolProp property name: Ps
 # Valid names:
@@ -410,6 +453,8 @@ HumidAir(T=Q(25, "°C"), Ps=Q(2, "bar"), R=Q(25, "%"))
 Use the `search()` and `describe()` methods to get more information about the properties:
 
 ```python
+from encomp.fluids import Fluid, HumidAir
+
 HumidAir.search("bulb")
 # ['B, Twb, T_wb, WetBulb: Wet-Bulb Temperature [K]',
 #  'T, Tdb, T_db: Dry-Bulb Temperature [K]']
@@ -421,12 +466,15 @@ Fluid.describe("Z")
 All property synonyms are valid instance attributes:
 
 ```python
+from encomp.fluids import Water
+from encomp.units import Quantity as Q
+
 Water.describe("PCRIT")
 # 'PCRIT, P_CRITICAL, Pcrit, p_critical, pcrit: Pressure at the critical point [Pa]'
 
 water = Water(T=Q(25, "°C"), P=Q(1, "atm"))
 
-water.p_critical, water.PCRIT
+critical = water.p_critical, water.PCRIT
 # (22064000.0 <Unit('pascal')>, 22064000.0 <Unit('pascal')>)
 ```
 
@@ -440,6 +488,7 @@ A mixture is given either by fractions folded into the fluid name or by a `compo
 
 ```python
 from encomp.fluids import Fluid
+from encomp.units import Quantity as Q
 
 Fluid("HEOS::CO2[0.7]&O2[0.3]", P=Q(10, "bar"), T=Q(300, "K"))
 
@@ -449,14 +498,20 @@ Fluid("HEOS", P=Q(10, "bar"), T=Q(300, "K"), composition={"CO2": 0.7, "O2": 0.3}
 For an incompressible mixture, the concentration is carried in the name instead, on the fluid's own basis (mass for glycols/brines, volume for the volume-specified antifreezes):
 
 ```python
+from encomp.fluids import Fluid
+from encomp.units import Quantity as Q
+
 Fluid("INCOMP::MEG[0.5]", P=Q(1, "bar"), T=Q(20, "°C"))  # 50 % ethylene glycol
 ```
 
 The {py:meth}`encomp.fluids.Fluid.assume_phase` method pins the phase, skipping CoolProp's phase-stability search, which dominates the cost for the HEOS/GERG mixture backends. It is a *speed* tool, not a validation tool: forcing a phase the fluid is not actually in returns `NaN` or a non-physical metastable root rather than raising.
 
 ```python
+from encomp.fluids import Fluid
+from encomp.units import Quantity as Q
+
 # ~100-1000x faster for mixtures, when the phase is known
-Fluid("HEOS::CO2[0.7]&O2[0.3]", P=Q(10, "bar"), T=Q(300, "K")).assume_phase("gas").D
+density = Fluid("HEOS::CO2[0.7]&O2[0.3]", P=Q(10, "bar"), T=Q(300, "K")).assume_phase("gas").D
 ```
 
 `IF97` (the default backend for {py:class}`encomp.fluids.Water`) is region-explicit and ignores an assumed phase; the call is a no-op there and emits a warning. Use `Fluid("HEOS::Water", ...)` if you need an assumed phase for water.
@@ -467,16 +522,21 @@ CoolProp evaluates vector inputs in a single backend call.
 The inputs are {py:class}`encomp.units.Quantity` instances with one-dimensional Numpy arrays as magnitude, all of the same length (or a single scalar, which is repeated).
 
 ```python
+import numpy as np
+
+from encomp.fluids import Water
+from encomp.units import Quantity as Q
+
 Water(T=Q(np.linspace(25, 50, 10), "°C"), P=Q(np.linspace(25, 50, 10), "bar"))
 # the repr shows only the head of each vector input
 # <Water (Liquid), P=[2500 2778 3056 ...] kPa, T=[25.0 27.8 30.6 ...] °C,
 # D=[998.1 997.5 996.8 ...] kg/m³, V=[0.9 0.8 0.8 ...] cP>
 
 # different phases
-Water(T=Q(np.linspace(25, 500, 10), "°C"), P=Q(np.linspace(0.5, 10, 10), "bar")).PHASE
+phases = Water(T=Q(np.linspace(25, 500, 10), "°C"), P=Q(np.linspace(0.5, 10, 10), "bar")).PHASE
 # <Quantity([0. 0. 5. 5. 5. 5. 5. 2. 2. 2.], 'dimensionless')>
 
-Water.PHASES
+phase_names = Water.PHASES
 # {0.0: 'Liquid',
 #  5.0: 'Gas',
 #  6.0: 'Two-phase',
@@ -536,10 +596,6 @@ The API mirrors {py:class}`encomp.fluids.Fluid`: any CoolProp input pair is supp
 
 To load additional methods for the `sympy.Symbol` class, import Sympy via the {py:mod}`encomp.sympy` module.
 
-```python
-from encomp.sympy import sp
-```
-
 ### Typesetting
 
 The following convenience methods are added to the `sp.Symbol` class:
@@ -551,6 +607,8 @@ The following convenience methods are added to the `sp.Symbol` class:
 These methods return new `sp.Symbol` instances with the same assumptions (*positive*, *real*, *integer*, ...) as the original.
 
 ```python
+from encomp.sympy import sp
+
 n = sp.Symbol("n", integer=True)
 
 n_test = n._("test")
@@ -583,6 +641,9 @@ Quantities can be substituted into Sympy expressions; the units are converted to
 The class method {py:meth}`encomp.units.Quantity.from_expr` converts an expression back to a quantity.
 
 ```python
+from encomp.sympy import sp
+from encomp.units import Quantity as Q
+
 x, y, z = sp.symbols("x, y, z")
 
 expr = 25 * x * y / z
@@ -603,7 +664,10 @@ Sympy integration only works with the seven SI dimensionalities, not with dimens
 Convert the expression to a function with {py:func}`encomp.sympy.get_function` instead:
 
 ```python
-from encomp.sympy import get_function
+import numpy as np
+
+from encomp.sympy import get_function, sp
+from encomp.units import Quantity as Q
 
 x, y, z = sp.symbols("x, y, z")
 
@@ -625,6 +689,9 @@ result_qty = fcn(
 Quantity objects combine directly with Sympy symbols; the units are converted to their symbolic representations by {py:meth}`encomp.units.Quantity._sympy_`.
 
 ```python
+from encomp.sympy import sp
+from encomp.units import Quantity as Q
+
 x, y, z = sp.symbols("x, y, z")
 
 # the type of the left object determines the output

--- a/encomp/coolprop/README.md
+++ b/encomp/coolprop/README.md
@@ -11,9 +11,10 @@ small eager inputs (scalars, short arrays) use the Python CoolProp path.
 
 ```python
 import polars as pl
+
 from encomp import coolprop as cp
 
-df = pl.DataFrame({"P": [50e5, 60e5], "T": [400.0, 450.0]})  # Pa, K
+df = pl.DataFrame({"P": [50e5, 60e5], "T": [400.0, 450.0], "R": [0.4, 0.6]})  # Pa, K, -
 
 df.select(
     cp.fluid("DMASS", "P", "T").alias("rho"),   # default: IF97 water
@@ -46,7 +47,7 @@ CORRECTNESS  plugin vs raw PropsSI (IF97 water): 0.0e+00 exact (D/H/S/Cp)
 
 SPEED (property D)            raw PropsSI | encomp map_batches | rust plugin | vs m_b
   N=1                            0.003 ms |          0.114 ms |    0.029 ms |  3.98x
-  N=1,000,000                  177.6   ms |        184.1   ms |   86.6   ms |  2.12x
+  N=1M                         177.6   ms |        184.1   ms |   86.6   ms |  2.12x
 
 PARALLELISM  4 independent props, ONE collect(), 1M rows
   encomp map_batches : combined 823 ms,  1.00x   serial (GIL)

--- a/encomp/tests/test_docs.py
+++ b/encomp/tests/test_docs.py
@@ -1,0 +1,150 @@
+"""Every ``python`` code block in the docs must be self-contained: it carries its own
+imports, is clean under ``ruff check``, type-checks under ``pyrefly``, and runs without
+error in isolation.
+
+This guards the documentation against drift -- a renamed API, a missing import, or a
+snippet that only worked as a continuation of an earlier block all fail here. The block
+is the unit: each fenced block is extracted verbatim, then linted, type-checked, and
+executed in a fresh namespace, so a block that relies on a name defined in a *previous*
+block is a failure.
+
+Discovery is dynamic: EVERY ``*.md`` under the repo (minus build/vendor/scratch dirs) is
+scanned for ```` ```python ```` fences, so adding a block anywhere is automatically covered
+-- no list to maintain.
+
+Checks per block:
+- ``ruff check`` under the repo's full ruff config (run with cwd at the repo root), so each
+  block is held to the same ruleset as the source (imports, naming, bugbear, ...) with no
+  per-block exceptions -- ``F401`` (unused import) and ``F821`` (undefined name) both gate.
+- ``pyrefly check``: the public API, as exercised by the examples, must type-check under
+  pyrefly too (not only pyright). A type error in an example is a real defect to fix, not
+  to ignore -- ``Q(1, "bar")`` infers ``Quantity[Pressure, float]``, so a correct block is
+  clean; an "unknown type" almost always traces back to a missing import.
+- execution in a fresh namespace: the snippet actually runs.
+
+A block can opt out of *execution and type-checking* (linting still applies, so its
+imports must be correct) with ``# test: no-run`` as its first line -- for a snippet that is
+pseudo-code, illustrates inferred types in comments, or intentionally shows a type/runtime
+error (e.g. the ``typeguard`` demos that pass a deliberately wrong dimensionality).
+
+The whole module skips when the repo docs are not on disk (e.g. running from an installed
+wheel via ``pytest --pyargs encomp.tests``); it is a source-tree / CI check. Individual
+tool checks skip if ``ruff`` / ``pyrefly`` are not installed.
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def _repo_root() -> Path | None:
+    for parent in Path(__file__).resolve().parents:
+        if (parent / "pyproject.toml").is_file() and (parent / "docs").is_dir():
+            return parent
+    return None
+
+
+def _tool(name: str) -> str | None:
+    candidate = Path(sys.executable).with_name(name)
+    if candidate.exists():
+        return str(candidate)
+    return shutil.which(name)
+
+
+ROOT = _repo_root()
+_RUFF = _tool("ruff")
+_PYREFLY = _tool("pyrefly")
+
+pytestmark = pytest.mark.skipif(
+    ROOT is None, reason="docs sources not on disk (installed wheel) -- source-tree check only"
+)
+
+_FENCE = re.compile(r"^```python\s*$(.*?)^```", re.MULTILINE | re.DOTALL)
+_NO_RUN = "# test: no-run"
+# directories that never hold published docs: build output, deps, caches, VCS, and the
+# repo's `temp/` scratch area
+_SKIP_DIRS = {
+    ".venv",
+    "_build",
+    "node_modules",
+    ".git",
+    "site-packages",
+    "target",
+    ".ruff_cache",
+    ".pytest_cache",
+    ".mypy_cache",
+    "temp",
+}
+
+
+def _doc_files(root: Path) -> list[Path]:
+    return sorted(p for p in root.rglob("*.md") if not _SKIP_DIRS.intersection(p.relative_to(root).parts))
+
+
+def _blocks() -> list[tuple[str, str]]:
+    """(id, code) for every ```python block, id = ``<relpath>:<line>``."""
+    if ROOT is None:
+        return []
+    cases: list[tuple[str, str]] = []
+    for md in _doc_files(ROOT):
+        text = md.read_text()
+        for m in _FENCE.finditer(text):
+            code: str = m.group(1).lstrip("\n")
+            line = text[: m.start()].count("\n") + 1
+            cases.append((f"{md.relative_to(ROOT)}:{line}", code))
+    return cases
+
+
+_CASES = _blocks()
+_IDS = [case_id for case_id, _ in _CASES]
+_CODES = [code for _, code in _CASES]
+
+
+def test_docs_have_blocks() -> None:
+    # tripwire: if extraction silently finds nothing, the checks below vacuously pass
+    assert len(_CASES) > 20, f"expected many doc code blocks, found {len(_CASES)}"
+
+
+@pytest.mark.skipif(_RUFF is None, reason="ruff not installed")
+@pytest.mark.parametrize("code", _CODES, ids=_IDS)
+def test_doc_block_lints(code: str, tmp_path: Path) -> None:
+    assert _RUFF is not None  # narrowed by the skipif above
+    block = tmp_path / "block.py"
+    block.write_text(code)
+    proc = subprocess.run(
+        [_RUFF, "check", "--no-cache", str(block)],
+        capture_output=True,
+        text=True,
+        cwd=ROOT,  # apply the repo's ruff config to every block, regardless of invocation cwd
+    )
+    assert proc.returncode == 0, f"ruff check failed:\n{proc.stdout}{proc.stderr}"
+
+
+@pytest.mark.skipif(_PYREFLY is None, reason="pyrefly not installed")
+@pytest.mark.parametrize("code", _CODES, ids=_IDS)
+def test_doc_block_typechecks(code: str, tmp_path: Path) -> None:
+    assert _PYREFLY is not None  # narrowed by the skipif above
+    if code.splitlines()[:1] == [_NO_RUN]:
+        pytest.skip("block marked # test: no-run")
+    block = tmp_path / "block.py"
+    block.write_text(code)
+    proc = subprocess.run(
+        [_PYREFLY, "check", str(block)],
+        capture_output=True,
+        text=True,
+        cwd=ROOT,  # resolve `encomp` via the project venv
+    )
+    assert proc.returncode == 0, f"pyrefly check failed:\n{proc.stdout}{proc.stderr}"
+
+
+@pytest.mark.parametrize("code", _CODES, ids=_IDS)
+def test_doc_block_runs(code: str) -> None:
+    if code.splitlines()[:1] == [_NO_RUN]:
+        pytest.skip("block marked # test: no-run")
+    exec(compile(code, "<doc block>", "exec"), {"__name__": "__doc_block__"})

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "encomp"
-version = "1.5.0"
+version = "1.5.1"
 description = "General-purpose library for engineering calculations"
 authors = [{ name = "William Laurén", email = "lauren.william.a@gmail.com" }]
 requires-python = ">=3.13"


### PR DESCRIPTION
Documentation nits queued for the next patch release, plus a test so they can't regress.

## What
- **New `encomp/tests/test_docs.py`** — dynamically extracts every ` ```python ` block from all `*.md` in the repo (minus build/vendor/scratch dirs) and, per block in isolation, runs `ruff check` (repo config), `pyrefly check`, and executes it. Discovery is dynamic, so any block added anywhere is covered automatically.
- **All doc blocks made self-contained** — each imports exactly what it uses and stands alone; bare expressions kept only to show a repr are bound to a name; intentional type/runtime-error demos (typeguard, invalid inputs) are marked `# test: no-run` (they still lint). No `# noqa` anywhere.
- **Nits**: `1,000,000 rows` → `1M rows` in the benchmarks; missing `Q` import in the mixtures example.

Local result: `116 passed, 14 skipped` (the 14 = 7 `# test: no-run` blocks × the run+typecheck checks they skip; ruff still lints them). The test file itself passes ruff + pyright (strict) + pyrefly.

## Design notes
- `ruff` runs with the **repo's full config** (B/N/SIM/ANN/I/…), so blocks are held to the same standard as the source — hence the bare-expr→named-assignment tidy-ups. Say the word if you'd rather docs use a relaxed ruff subset.
- `pyrefly` (not just pyright) gates each block, so the public API is verified under pyrefly too.
- `# test: no-run` skips execution **and** type-checking (linting still applies).

## Heads-up: CI wiring
This test runs from the **source tree** (it needs the docs on disk **and** the compiled plugin for the runtime check). As configured it will **not** run in the current CI jobs — `typecheck` has the source but no built plugin, and the wheel `test` job has the plugin but not the docs (the module self-skips there). To actually enforce it in CI we'd add a small job that builds the plugin in the checkout (`maturin develop`) and runs `pytest encomp/tests/test_docs.py`, or add a pre-commit hook. Happy to wire that up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)