### PR TITLE
ci: sync uv.lock to 1.5.1 + require CI on all PRs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,8 +12,10 @@ name: encomp release
 #                    Publishing (OIDC -- no token/secret stored anywhere)
 on:
   workflow_dispatch:
+  # no paths filter: the checks below are REQUIRED by branch protection, and a required
+  # check that is skipped (paths not matched) would block the PR forever -- so every PR
+  # runs them. The concurrency group cancels superseded runs.
   pull_request:
-    paths: ["encomp/**", "rust/**", "scripts/**", "pyproject.toml", ".github/workflows/release.yml"]
   push:
     tags: ["v*"]
 

--- a/uv.lock
+++ b/uv.lock
@@ -495,7 +495,7 @@ wheels = [
 
 [[package]]
 name = "encomp"
-version = "1.5.0"
+version = "1.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "asttokens" },


### PR DESCRIPTION
Fixes the failed v1.5.1 release and closes the branch-protection gap.

- **`uv.lock`**: re-locked to `1.5.1` (the version bump left it at 1.5.0, so `uv sync --locked` failed in typecheck — the reason the v1.5.1 tag run went red before publishing; nothing was published).
- **`release.yml`**: dropped the `pull_request` paths filter. The CI jobs are now **required** by branch protection; a required check skipped due to an unmatched paths filter would block a PR forever, so every PR must run them. Concurrency still cancels superseded runs.

Branch protection on `main` now requires all 13 checks (typecheck + 4 builds + 8 tests) + a PR, enforced for admins — a red PR can no longer be merged. This PR is the first to go through that gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)