### PR TITLE
Docs: logo + gallery thumbnail, runnable doc blocks, static string rejection; release 1.5.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # encomp
 
+<img src="https://raw.githubusercontent.com/wlaur/encomp/main/docs/img/logo.png" alt="encomp logo" width="150">
+
 > General-purpose library for *en*gineering *comp*utations.
 
 `encomp` is tested on Windows, Linux, and macOS, with Python 3.13 and 3.14.
@@ -63,8 +65,7 @@ Common dimensionalities are defined in the `encomp.utypes` module.
 A newly created dimensionality gets a class name of the form `Dimensionality[...]` (for example `Quantity[Dimensionality[[mass] ** 2 / [length] ** 3]]`).
 
 ```python
-# test: no-run
-
+from encomp.units import ExpectedDimensionalityError
 from encomp.units import Quantity as Q
 from encomp.utypes import MassFlow, Volume
 
@@ -83,8 +84,10 @@ rho = m / V  # Quantity[Density, float]
 # the type checker does not know how to combine these units
 m_ = Q(25, "kg/week")  # Quantity[UnknownDimensionality, float]
 
-# at runtime, the dimensionality of m_ will be evaluated to MassFlow
-isinstance(m_, Q[MassFlow])  # True
+# at runtime, the dimensionality of m_ is evaluated to MassFlow;
+# Q[MassFlow] is a real class, but parameterized isinstance is a runtime-only feature
+# pyrefly: ignore[invalid-argument]
+assert isinstance(m_, Q[MassFlow])
 
 # these operations (Mass**2 divided by Volume) are not explicitly defined as overloads
 # at runtime, the type will be evaluated to
@@ -94,13 +97,15 @@ x = m**2 / V  # Quantity[UnknownDimensionality, float]
 # the unit name "meter cubed" is not defined using an overload
 y = Q(15, "meter cubed").asdim(Volume)  # Quantity[Volume, float]
 
-# if the explicit dimensionality does not match
-# the unit, an error is raised at runtime
-
-y = Q(15, "meter cubed").asdim(MassFlow)
-# ExpectedDimensionalityError: Cannot convert 15.0 m³ to dimensionality
-# <class 'encomp.utypes.MassFlow'>, the dimensions do not match:
-# [length] ** 3 != [mass] / [time]
+# if the explicit dimensionality does not match the unit,
+# an error is raised at runtime
+try:
+    Q(15, "meter cubed").asdim(MassFlow)
+except ExpectedDimensionalityError as e:
+    print(f"Error: {e}")
+    # Cannot convert 15.0 m³ to dimensionality
+    # <class 'encomp.utypes.MassFlow'>, the dimensions do not match:
+    # [length] ** 3 != [mass] / [time]
 ```
 
 ### Runtime type checking
@@ -109,11 +114,9 @@ The `Quantity` subtypes also restrict function and class attribute types at runt
 The `typeguard.typechecked` decorator checks function inputs and outputs:
 
 ```python
-# test: no-run
+from typing import Any, TypedDict, cast
 
-from typing import Any, TypedDict
-
-from typeguard import typechecked
+from typeguard import TypeCheckError, typechecked
 
 from encomp.units import Quantity as Q
 from encomp.utypes import Length, Pressure, Temperature
@@ -125,9 +128,16 @@ def some_func(T: Q[Temperature, float]) -> tuple[Q[Length, float], Q[Pressure, f
 
 
 some_func(Q(12, "K"))  # the dimensionalities check out
-some_func(Q(26, "kW"))  # raises an exception:
-# TypeCheckError: argument "T" (encomp.units.Quantity[Power, float])
-# is not an instance of encomp.units.Quantity[Temperature, float]
+
+# a static type checker rejects some_func(Q(26, "kW")) before the code runs;
+# typeguard catches the same error at runtime for values the checker cannot
+# see through (simulated here by casting to Any)
+try:
+    some_func(cast(Any, Q(26, "kW")))
+except TypeCheckError as e:
+    print(f"Error: {e}")
+    # argument "T" (encomp.units.Quantity[Power, float])
+    # is not an instance of encomp.units.Quantity[Temperature, float]
 
 
 class OutputDict(TypedDict):
@@ -137,12 +147,16 @@ class OutputDict(TypedDict):
 
 @typechecked
 def another_func(_s: Q[Length, Any]) -> OutputDict:
-    return {"T": Q(25, "m"), "P": Q(25, "kPa")}
+    # the value for the key "T" has the wrong dimensionality
+    return {"T": cast(Any, Q(25, "m")), "P": Q(25, "kPa")}
 
 
-another_func(Q(25, "m"))
-# TypeCheckError: value of key 'T' of the return value (dict)
-# is not an instance of encomp.units.Quantity[Temperature]
+try:
+    another_func(Q(25, "m"))
+except TypeCheckError as e:
+    print(f"Error: {e}")
+    # value of key 'T' of the return value (dict)
+    # is not an instance of encomp.units.Quantity[Temperature]
 ```
 
 To create a new dimensionality (for example temperature difference per mass flow rate), combine the `pint.UnitsContainer` objects stored in the `dimensions` class attribute.
@@ -257,7 +271,7 @@ from encomp.fluids import Water
 from encomp.units import Quantity as Q
 
 df = pl.DataFrame({"P": [50e5, 60e5], "T": [400.0, 450.0]})  # Pa, K
-w = Water(P=Q(pl.col("P"), "Pa"), T=Q(pl.col("T"), "K"))
+w: Water[pl.Expr] = Water(P=Q(pl.col("P"), "Pa"), T=Q(pl.col("T"), "K"))
 
 # these independent CoolProp properties run in parallel across cores
 df.select(w.D.m.alias("rho"), w.H.m.alias("h"), w.S.m.alias("s"))
@@ -307,6 +321,9 @@ from encomp.sympy import sp
 from encomp.units import Quantity as Q
 
 n = sp.Symbol("n", integer=True)
+
+# the _ / __ methods are added to sp.Symbol at runtime by encomp.sympy
+# pyrefly: ignore[missing-attribute]
 n._("H_2O").__("out")  # n_{\text{H}_2\text{O}}^{\text{out}}, keeps the integer assumption
 
 x, y, z = sp.symbols("x, y, z")

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -61,13 +61,15 @@ source_suffix = {
 }
 
 # MyST features used by the docs: ::: colon fences (so autodoc directives can live in .md via
-# {eval-rst}), $...$ / $$...$$ math, and definition/field lists.
+# {eval-rst}), $...$ / $$...$$ math, definition/field lists, and raw HTML <img> tags (the
+# README logo needs an <img> tag to control its rendered size on GitHub/PyPI).
 myst_enable_extensions = [
     "colon_fence",
     "deflist",
     "fieldlist",
     "dollarmath",
     "substitution",
+    "html_image",
 ]
 
 # generate anchors for headings h1-h3 so in-page Markdown links like
@@ -102,7 +104,10 @@ html_theme_options = {"sidebar_hide_name": True}
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ["_static"]
+# img/ is included so the logo is available in the build output (the notebook
+# gallery thumbnail below references it; nbsphinx does not copy thumbnail
+# files that are not part of a document)
+html_static_path = ["_static", "img"]
 
 
 html_css_files = [
@@ -142,11 +147,11 @@ todo_include_todos = True
 pygments_style = "sphinx"
 pygments_dark_style = "monokai"
 
-# the images must be included in the _build dir when generating the HTML docs
-# make sure they are referenced inside the corresponding notebook
+# gallery thumbnails for the example notebooks; the values must exist in the build
+# output -- _static/logo.svg comes from the img/ entry in html_static_path above
 # NOTE: the .ipynb suffix is not included in the names
 nbsphinx_thumbnails = {
-    "notebooks/test": "_images/logo.svg",
+    "notebooks/test": "_static/logo.svg",
 }
 
 add_module_names = False

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -43,10 +43,12 @@ Quantities can also be constructed from unit registry attributes:
 from encomp.units import UNIT_REGISTRY
 from encomp.units import Quantity as Q
 
-d = 50 * UNIT_REGISTRY.m
-v = d / UNIT_REGISTRY.s
+# the registry attributes are typed for use as Quantity units, not for
+# direct arithmetic, so these operations need pyrefly suppressions
+d = 50 * UNIT_REGISTRY.m  # pyrefly: ignore[unsupported-operation]
+v = d / UNIT_REGISTRY.s  # pyrefly: ignore[unsupported-operation]
 
-mf = Q(25, UNIT_REGISTRY.kg / UNIT_REGISTRY.h)
+mf = Q(25, UNIT_REGISTRY.kg / UNIT_REGISTRY.h)  # pyrefly: ignore[unsupported-operation]
 ```
 
 ### Quantity types
@@ -114,8 +116,11 @@ pressure.check(Pressure)  # True
 pressure.check("psi")  # True
 
 # alternative using isinstance()
+# (parameterized isinstance is a runtime-only feature, hence the suppressions)
 
+# pyrefly: ignore[invalid-argument]
 isinstance(pressure, Q[Pressure])  # True
+# pyrefly: ignore[invalid-argument]
 isinstance(pressure, Q[Length])  # False
 
 # complex types must use isinstance_types
@@ -131,8 +136,6 @@ isinstance_types(pressure, Q)  # True
 For functions and methods, use the `typeguard.typechecked` decorator instead of explicit checks in the function body:
 
 ```python
-# test: no-run
-
 from typeguard import typechecked
 
 from encomp.units import Quantity as Q
@@ -219,20 +222,28 @@ A temperature *difference* in a degree scale is written with the prefix `delta_`
 Temperature ({py:class}`encomp.utypes.Temperature`) and temperature difference ({py:class}`encomp.utypes.TemperatureDifference`) are distinct dimensionalities and deliberately not interchangeable: a difference cannot silently be used as an absolute temperature.
 
 ```python
-# test: no-run
+from pint.errors import OffsetUnitCalculusError
 
+from encomp.units import DimensionalityTypeError
 from encomp.units import Quantity as Q
 
 temp_diff = Q(5, "delta_degC")  # 5 Δ°C
 
-# this is not allowed
-temp_diff.to("degC")
-# DimensionalityTypeError: Cannot convert Δ°C (dimensionality TemperatureDifference)
-# to °C (dimensionality Temperature)
+# a temperature difference cannot be converted to an absolute temperature
+try:
+    temp_diff.to("degC")
+except DimensionalityTypeError as e:
+    print(f"Error: {e}")
+    # Cannot convert Δ°C (dimensionality TemperatureDifference)
+    # to °C (dimensionality Temperature)
 
 Q(25, "degC") - Q(36, "degC")  # -11 Δ°C
 
-Q(4.19, "kJ/kg/K") * Q(5, "°C")  # raises OffsetUnitCalculusError
+# multiplying with an offset unit (°C) is ambiguous
+try:
+    Q(4.19, "kJ/kg/K") * Q(5, "°C")
+except OffsetUnitCalculusError as e:
+    print(f"Error: {e}")
 
 # this is not the result we're after, °C is offset by 273.15 K
 Q(4.19, "kJ/kg/K") * Q(5, "°C").to("K")  # 1165.4485 kJ/kg
@@ -298,7 +309,8 @@ from encomp.utypes import Pressure
 # from pint.errors import DimensionalityError
 
 try:
-    Q(25, "bar") + Q(25, "m")
+    # a static type checker rejects this addition as well
+    Q(25, "bar") + Q(25, "m")  # pyrefly: ignore[unsupported-operation]
 except DimensionalityError as e:
     print(f"Error: {e}")
 
@@ -337,57 +349,13 @@ class Model(BaseModel):
     r: Q[Dimensionless, float] = Q(0.5)
 
 
-# if the input dimensionalities do not match the type hint,
-# pydantic.ValidationError is raised
+# if the input dimensionality does not match the type hint,
+# encomp.units.ExpectedDimensionalityError is raised
 model = Model(a=Q(25, "cSt"), m=Q(25, "kg"), s=Q(25, "cm"))
 
 # Quantity fields round-trip through JSON, including the magnitude type
 Model.model_validate_json(model.model_dump_json())
 ```
-
-`pydantic_settings.BaseSettings` reads, converts and validates key-value pairs from an `.env`-file.
-
-`.env`-file:
-
-```text
-any_quantity=1.215 kJ/kg/K
-mass=24 kg
-length=25 m
-ratio=0.25
-```
-
-`.py`-file:
-
-```python
-# test: no-run
-
-from pydantic_settings import BaseSettings, SettingsConfigDict
-
-from encomp.units import Quantity as Q
-from encomp.utypes import Dimensionless, Length, Mass, Pressure
-
-
-class Settings(BaseSettings):
-    model_config = SettingsConfigDict(validate_assignment=True)
-
-    any_quantity: Q
-    mass: Q[Mass]
-    length: Q[Length]
-
-    ratio: Q[Dimensionless] = Q(0)
-    pressure: Q[Pressure] = Q(1, "atm")
-
-
-# parameters that are not explicitly passed here are read from the .env-file
-s = Settings(ratio=0.75)
-
-# raises pydantic.ValidationError (since validate_assignment is True)
-s.mass = Q(25, "bar")
-```
-
-:::{note}
-Vector quantities, for example `Q([25, 26], "kg")`, cannot be specified with an `.env`-file.
-:::
 
 ## The Fluid class
 
@@ -400,7 +368,7 @@ Not every combination of input parameters can fix the state: with an invalid inp
 An invalid property *name*, on the other hand, raises `ValueError`.
 
 ```python
-# test: no-run
+from typing import Any
 
 from encomp.fluids import Fluid
 from encomp.units import Quantity as Q
@@ -408,9 +376,12 @@ from encomp.units import Quantity as Q
 Fluid("toluene", T=Q(25, "°C"), P=Q(2, "bar"))
 # <Fluid "toluene", P=200 kPa, T=25.0 °C, D=862.3 kg/m³, V=0.55 cP>
 
-# PCRIT cannot be used to fix the state (it is an output-only property,
-# not one of the FluidState inputs, so it is rejected statically too)
-invalid_inputs = Fluid("water", D=Q(500, "kg/m³"), PCRIT=Q(1, "bar"))
+# PCRIT cannot be used to fix the state: it is an output-only property, not one
+# of the FluidState inputs, so a static type checker rejects it at the call
+# site (the inputs are routed through Any here to show the runtime behavior)
+state: Any = {"D": Q(500, "kg/m³"), "PCRIT": Q(1, "bar")}
+
+invalid_inputs = Fluid("water", **state)
 # <Fluid "water", P=nan kPa, T=nan °C, D=nan kg/m³, V=nan cP>
 
 # every property is nan (CoolProp emits a warning about the invalid input pair)
@@ -434,20 +405,28 @@ HumidAir(T=Q(25, "°C"), P=Q(2, "bar"), R=Q(25, "%"))
 # <HumidAir, P=200 kPa, T=25.0 °C, R=0.25, Vda=0.4 m³/kg, Vha=0.4 m³/kg, M=0.018 cP>
 ```
 
-Property names must match CoolProp's exactly:
+Property names must match CoolProp's exactly.
+An invalid state-input name is rejected statically at the call site, and the constructor raises `ValueError` at runtime:
 
 ```python
-# test: no-run
+from typing import Any
 
 from encomp.fluids import HumidAir
 from encomp.units import Quantity as Q
 
-HumidAir(T=Q(25, "°C"), Ps=Q(2, "bar"), R=Q(25, "%"))
-# ValueError: Invalid CoolProp property name: Ps
-# Valid names:
-# B, C, CV, CVha, Cha, Conductivity, D, DewPoint, Enthalpy, Entropy, H, Hda, Hha,
-# HumRat, K, M, Omega, P, P_w, R, RH, RelHum, S, Sda, Sha, T, T_db, T_dp, T_wb, Tdb,
-# Tdp, Twb, V, Vda, Vha, Visc, W, WetBulb, Y, Z, cp, cp_ha, cv_ha, k, mu, psi_w
+# "Ps" is not a valid property name (the inputs are routed through Any here,
+# since HumidAir(T=..., Ps=..., R=...) is also rejected statically)
+state: Any = {"T": Q(25, "°C"), "Ps": Q(2, "bar"), "R": Q(25, "%")}
+
+try:
+    HumidAir(**state)
+except ValueError as e:
+    print(f"Error: {e}")
+    # Invalid CoolProp property name: Ps
+    # Valid names:
+    # B, C, CV, CVha, Cha, Conductivity, D, DewPoint, Enthalpy, Entropy, H, Hda, Hha,
+    # HumRat, K, M, Omega, P, P_w, R, RH, RelHum, S, Sda, Sha, T, T_db, T_dp, T_wb, Tdb,
+    # Tdp, Twb, V, Vda, Vha, Visc, W, WetBulb, Y, Z, cp, cp_ha, cv_ha, k, mu, psi_w
 ```
 
 Use the `search()` and `describe()` methods to get more information about the properties:
@@ -566,7 +545,7 @@ from encomp.fluids import Water
 from encomp.units import Quantity as Q
 
 df = pl.DataFrame({"P": [50e5, 60e5], "T": [400.0, 450.0]})  # Pa, K
-w = Water(P=Q(pl.col("P"), "Pa"), T=Q(pl.col("T"), "K"))
+w: Water[pl.Expr] = Water(P=Q(pl.col("P"), "Pa"), T=Q(pl.col("T"), "K"))
 
 # independent CoolProp properties evaluated in parallel across cores
 df.select(w.D.m.alias("rho"), w.H.m.alias("h"), w.S.m.alias("s"))
@@ -611,7 +590,8 @@ from encomp.sympy import sp
 
 n = sp.Symbol("n", integer=True)
 
-n_test = n._("test")
+# the _ method is added to sp.Symbol at runtime by encomp.sympy
+n_test = n._("test")  # pyrefly: ignore[missing-attribute]
 str(n_test)
 # n_{\text{test}}
 

--- a/encomp/tests/test_docs.py
+++ b/encomp/tests/test_docs.py
@@ -5,8 +5,8 @@ error in isolation.
 This guards the documentation against drift -- a renamed API, a missing import, or a
 snippet that only worked as a continuation of an earlier block all fail here. The block
 is the unit: each fenced block is extracted verbatim, then linted, type-checked, and
-executed in a fresh namespace, so a block that relies on a name defined in a *previous*
-block is a failure.
+executed on its own, so a block that relies on a name defined in a *previous* block is
+a failure.
 
 Discovery is dynamic: EVERY ``*.md`` under the repo (minus build/vendor/scratch dirs) is
 scanned for ```` ```python ```` fences, so adding a block anywhere is automatically covered
@@ -16,16 +16,25 @@ Checks per block:
 - ``ruff check`` under the repo's full ruff config (run with cwd at the repo root), so each
   block is held to the same ruleset as the source (imports, naming, bugbear, ...) with no
   per-block exceptions -- ``F401`` (unused import) and ``F821`` (undefined name) both gate.
-- ``pyrefly check``: the public API, as exercised by the examples, must type-check under
-  pyrefly too (not only pyright). A type error in an example is a real defect to fix, not
-  to ignore -- ``Q(1, "bar")`` infers ``Quantity[Pressure, float]``, so a correct block is
-  clean; an "unknown type" almost always traces back to a missing import.
-- execution in a fresh namespace: the snippet actually runs.
+- ``pyrefly check`` against the repo config (``--config`` is passed explicitly: without
+  it, pyrefly silently skips files outside a configured project and reports "0 errors"
+  without analyzing anything). A type error in an example is a real defect to fix --
+  ``Q(1, "bar")`` infers ``Quantity[Pressure, float]``, so a correct block is clean.
+  Blocks that demonstrate runtime-only dynamic behavior (parameterized ``isinstance``,
+  the sympy ``_``/``__`` methods added at import time, deliberately-invalid operations
+  shown inside ``try``/``except``) carry explicit ``# pyrefly: ignore[...]`` comments;
+  the repo config elevates ``unused-ignore`` to an error, so a suppression that stops
+  matching real errors fails this test instead of lingering.
+- execution as a real script: the block is written to a file and run in a fresh
+  interpreter with a temporary working directory, exactly as a reader would run it.
+  A subprocess (not in-process ``exec``) is required for the ``typeguard`` examples --
+  ``@typechecked`` instruments by re-reading the module source, which does not exist for
+  exec'd strings -- and the temporary cwd lets blocks create scratch files (e.g. the
+  ``.env`` example) without touching the repo.
 
-A block can opt out of *execution and type-checking* (linting still applies, so its
-imports must be correct) with ``# test: no-run`` as its first line -- for a snippet that is
-pseudo-code, illustrates inferred types in comments, or intentionally shows a type/runtime
-error (e.g. the ``typeguard`` demos that pass a deliberately wrong dimensionality).
+There is deliberately no opt-out: a snippet that cannot run as written (for example one
+that demonstrates an exception) shows the failure with ``try: ... except SomeError:``
+instead, so it still executes.
 
 The whole module skips when the repo docs are not on disk (e.g. running from an installed
 wheel via ``pytest --pyargs encomp.tests``); it is a source-tree / CI check. Individual
@@ -66,7 +75,6 @@ pytestmark = pytest.mark.skipif(
 )
 
 _FENCE = re.compile(r"^```python\s*$(.*?)^```", re.MULTILINE | re.DOTALL)
-_NO_RUN = "# test: no-run"
 # directories that never hold published docs: build output, deps, caches, VCS, and the
 # repo's `temp/` scratch area
 _SKIP_DIRS = {
@@ -130,12 +138,14 @@ def test_doc_block_lints(code: str, tmp_path: Path) -> None:
 @pytest.mark.parametrize("code", _CODES, ids=_IDS)
 def test_doc_block_typechecks(code: str, tmp_path: Path) -> None:
     assert _PYREFLY is not None  # narrowed by the skipif above
-    if code.splitlines()[:1] == [_NO_RUN]:
-        pytest.skip("block marked # test: no-run")
+    assert ROOT is not None  # narrowed by the module-level skipif
     block = tmp_path / "block.py"
     block.write_text(code)
+    # --config is required: without it, pyrefly silently checks NOTHING for a file
+    # outside any configured project (it reports "0 errors" without analyzing), so
+    # the block must be checked against the repo config explicitly
     proc = subprocess.run(
-        [_PYREFLY, "check", str(block)],
+        [_PYREFLY, "check", "--config", str(ROOT / "pyproject.toml"), str(block)],
         capture_output=True,
         text=True,
         cwd=ROOT,  # resolve `encomp` via the project venv
@@ -144,7 +154,13 @@ def test_doc_block_typechecks(code: str, tmp_path: Path) -> None:
 
 
 @pytest.mark.parametrize("code", _CODES, ids=_IDS)
-def test_doc_block_runs(code: str) -> None:
-    if code.splitlines()[:1] == [_NO_RUN]:
-        pytest.skip("block marked # test: no-run")
-    exec(compile(code, "<doc block>", "exec"), {"__name__": "__doc_block__"})
+def test_doc_block_runs(code: str, tmp_path: Path) -> None:
+    block = tmp_path / "block.py"
+    block.write_text(code)
+    proc = subprocess.run(
+        [sys.executable, str(block)],
+        capture_output=True,
+        text=True,
+        cwd=tmp_path,  # scratch files a block creates (e.g. the .env example) land in tmp
+    )
+    assert proc.returncode == 0, f"doc block failed:\n--- stdout:\n{proc.stdout}\n--- stderr:\n{proc.stderr}"

--- a/encomp/tests/test_gases.py
+++ b/encomp/tests/test_gases.py
@@ -55,7 +55,8 @@ def test_ideal_gas_density() -> None:
     # args are cast (needed for both checkers), and pyrefly additionally cannot solve
     # the shared constrained TypeVar across multiple arguments at all
     assert_type(  # pyrefly: ignore[assert-type]
-        ideal_gas_density(Q(25, "degC"), Q(12, "bar"), Q(12, "g/mol")), Q[Density, float]
+        ideal_gas_density(Q(25, "degC"), Q(12, "bar"), Q(12, "g/mol")),  # pyrefly: ignore[bad-specialization]
+        Q[Density, float],
     )
 
     ret = ideal_gas_density(Q([25, 26], "degC"), cast(Any, Q(12, "bar")), cast(Any, Q(12, "g/mol")))  # pyrefly: ignore[bad-argument-type, bad-specialization]

--- a/encomp/tests/test_static_typing.py
+++ b/encomp/tests/test_static_typing.py
@@ -1,0 +1,84 @@
+"""String inputs to ``Quantity`` are deliberately unsupported: the magnitude and unit
+are always passed separately (``Q(24, "kg")``, never ``Q("24 kg")``).
+
+The runtime already rejects strings (``_validate_magnitude``); these tests additionally
+pin the *static* rejection: the fallback ``Quantity.__new__`` overload enumerates the
+supported magnitude types and excludes ``str``, so ``Q("24 kg")`` must fail both pyright
+and pyrefly. A valid twin snippet is checked as a control, so a failure of the invalid
+snippet cannot be explained away by import-resolution problems.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+from ..units import Quantity as Q
+
+
+def _tool(name: str) -> str | None:
+    candidate = Path(sys.executable).with_name(name)
+    if candidate.exists():
+        return str(candidate)
+    return shutil.which(name)
+
+
+_PYREFLY = _tool("pyrefly")
+_PYRIGHT = _tool("pyright")
+
+_VALID = """
+from encomp.units import Quantity as Q
+
+q = Q(24, "kg")
+"""
+
+_INVALID = """
+from encomp.units import Quantity as Q
+
+q1 = Q("24 kg")
+q2 = Q("24", "kg")
+"""
+
+_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _check(cmd: list[str], code: str, tmp_path: Path) -> int:
+    snippet = tmp_path / "snippet.py"
+    snippet.write_text(code)
+    proc = subprocess.run(
+        [*cmd, str(snippet)],
+        capture_output=True,
+        text=True,
+        cwd=_ROOT,
+    )
+    return proc.returncode
+
+
+@pytest.mark.skipif(_PYREFLY is None, reason="pyrefly not installed")
+def test_string_input_rejected_by_pyrefly(tmp_path: Path) -> None:
+    assert _PYREFLY is not None  # narrowed by the skipif above
+    # --config is required: without it, pyrefly silently skips files outside any
+    # configured project (reporting "0 errors" without analyzing)
+    cmd = [_PYREFLY, "check", "--config", str(_ROOT / "pyproject.toml")]
+    assert _check(cmd, _VALID, tmp_path) == 0, "control snippet must type-check"
+    assert _check(cmd, _INVALID, tmp_path) != 0, "string inputs must not type-check"
+
+
+@pytest.mark.skipif(_PYRIGHT is None, reason="pyright not installed")
+def test_string_input_rejected_by_pyright(tmp_path: Path) -> None:
+    assert _PYRIGHT is not None  # narrowed by the skipif above
+    assert _check([_PYRIGHT], _VALID, tmp_path) == 0, "control snippet must type-check"
+    assert _check([_PYRIGHT], _INVALID, tmp_path) != 0, "string inputs must not type-check"
+
+
+def test_string_input_rejected_at_runtime() -> None:
+    with pytest.raises(ValueError):
+        Q(cast(Any, "24 kg"))
+
+    with pytest.raises(ValueError):
+        Q(cast(Any, "24"), "kg")

--- a/encomp/units.py
+++ b/encomp/units.py
@@ -908,9 +908,12 @@ class Quantity(
     @overload
     def __new__(cls, val: MT, unit: str) -> Quantity[UnknownDimensionality, MT]: ...
     @overload
-    def __new__(  # fallback overload: matches anything not covered above
+    def __new__(  # fallback overload: any supported magnitude type not covered above
         cls,
-        val: Any,  # noqa: ANN401
+        # str is deliberately absent: string parsing like Q("24 kg") must be rejected
+        # statically (it also raises ValueError at runtime) -- Quantity magnitudes and
+        # units are always passed separately
+        val: float | np.ndarray[Any, Any] | pl.Series | pl.Expr | Sequence[float] | Quantity[Any, Any] | sp.Basic,
         unit: Any = None,  # noqa: ANN401
         _depth: int = 0,
     ) -> Quantity[Any, Any]: ...

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "encomp"
-version = "1.5.2"
+version = "1.5.3"
 description = "General-purpose library for engineering calculations"
 authors = [{ name = "William Laurén", email = "lauren.william.a@gmail.com" }]
 requires-python = ">=3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -495,7 +495,7 @@ wheels = [
 
 [[package]]
 name = "encomp"
-version = "1.5.2"
+version = "1.5.3"
 source = { editable = "." }
 dependencies = [
     { name = "asttokens" },


### PR DESCRIPTION
## Summary

- **Logo restored on the README / docs landing page.** The MyST migration (README as single source of truth) dropped the logo the old `index.rst` carried. It is back at the top of the README via an absolute `raw.githubusercontent.com` URL with an `<img width=...>` tag, so it renders on GitHub, PyPI, and in the Sphinx docs (MyST `html_image` extension enabled for the tag).
- **Notebook gallery thumbnail fixed** (`examples.html`). The thumbnail pointed at `_images/logo.svg`, which only existed as a side effect of the old `index.rst` image; the logo is now served from `_static` (`img/` added to `html_static_path`).
- **`# test: no-run` removed entirely.** Every doc code block now runs: error demonstrations use `try: ... except SomeError as e:` instead of opting out. The doc-block test executes each block as a real script in a subprocess (typeguard's `@typechecked` cannot instrument exec'd strings) with a temporary cwd.
- **The pyrefly doc gate was silently vacuous** — pyrefly reports "0 errors" without analyzing anything for files outside a configured project, so the per-block type check never checked a single block. It now passes `--config` explicitly. Blocks demonstrating runtime-only behavior (parameterized `isinstance`, sympy `_`/`__` methods added at import time, deliberately invalid operations inside `try/except`) carry explicit `# pyrefly: ignore[...]` suppressions, kept honest by the repo's `unused-ignore = error` setting.
- **String inputs to `Quantity` are now rejected statically too.** They have always been rejected at runtime (magnitude and unit are passed separately, by design), but the catch-all `__new__` overload typed the magnitude as `Any`, so `Q("24 kg")` type-checked. The fallback overload now enumerates the supported magnitude types; a regression test (valid control snippet + invalid snippet) pins the behavior under both pyright and pyrefly.
- **The broken pydantic-settings `.env` example is removed** — reading quantities from an `.env` file is not a supported pattern, and the example never worked as written (no `env_file` configured, and `Quantity` does not accept strings).
- **Release 1.5.3** (patch bump + `uv.lock` sync).

## Test plan

- [x] full suite: 610 passed (includes 127 doc-block checks: ruff + pyrefly + subprocess run for all 42 blocks, plus the new static-typing regression tests)
- [x] pyright strict + pyrefly: 0 errors
- [x] clean Sphinx build; verified `index.html` shows the logo and `examples.html` references `_static/logo.svg` (present in output)
- [x] logo URL serves `image/png` (24 kB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NZGKhUyVn7vSoYM7ZkAeMJ