### PR TITLE
Fix 1.6.1 review items

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ name: encomp release
 # + bundled libCoolProp, all in one wheel) for macOS / Linux / Windows, run the full
 # test suite against each wheel on Python 3.13 and 3.14, and publish to PyPI on a tag.
 #
-#   typecheck      -> pyright (strict) + pyrefly, the required-green checkers
+#   typecheck      -> pyright (strict) + pyrefly, plus source-only doc/static tests
 #                     (ty is advisory and intentionally not gated)
 #   build-wheels   -> one wheel per OS/arch (abi3 cp313 => runs on 3.13+)
 #   test           -> install each prebuilt wheel + run pytest, every OS x py
@@ -44,6 +44,7 @@ jobs:
       - run: uv sync --locked --no-install-project
       - run: uv run --no-sync pyright
       - run: uv run --no-sync pyrefly check
+      - run: uv run --no-sync pytest encomp/tests/test_docs.py encomp/tests/test_static_typing.py -q
 
   build-wheels:
     name: build ${{ matrix.os }}
@@ -93,7 +94,8 @@ jobs:
           python -m pip install --upgrade pip
           # install the PREBUILT encomp wheel (abi3 cp313 installs on 3.14 too) by
           # name so it is not rebuilt from source; deps + test deps come from PyPI
-          pip install --find-links wheelhouse encomp pytest hypothesis
+          version=$(python -c 'from pathlib import Path; wheels = sorted(Path("wheelhouse").glob("encomp-*.whl")); assert len(wheels) == 1, f"expected exactly one encomp wheel, found {len(wheels)}"; print(wheels[0].name.split("-")[1])')
+          pip install --find-links wheelhouse "encomp==$version" pytest hypothesis
           python -c "from encomp import coolprop as cp; assert cp.self_check(), 'plugin self_check failed'"
           python -m pytest --pyargs encomp.tests -q
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,8 +86,7 @@ jobs:
       - uses: actions/download-artifact@v8.0.1
         with:
           path: wheelhouse
-          pattern: wheels-*
-          merge-multiple: true
+          name: wheels-${{ matrix.os }}
       - name: Install the prebuilt wheel + run the full suite
         shell: bash
         run: |

--- a/README.md
+++ b/README.md
@@ -92,8 +92,7 @@ m_ = Q(25, "kg/week")  # Quantity[UnknownDimensionality, float]
 
 # at runtime, the dimensionality of m_ is evaluated to MassFlow;
 # Q[MassFlow] is a real class, but parameterized isinstance is a runtime-only feature
-# pyrefly: ignore[invalid-argument]
-assert isinstance(m_, Q[MassFlow])
+assert isinstance(m_, Q[MassFlow])  # pyright: ignore[reportArgumentType]
 
 # these operations (Mass**2 divided by Volume) are not explicitly defined as overloads
 # at runtime, the type will be evaluated to
@@ -239,7 +238,7 @@ Water(Q=Q(0.5), T=Q(170, "degC"))
 # <Water (Two-phase), P=792 kPa, T=170.0 °C, D=8.2 kg/m³, V=nan cP>
 
 Water(H=Q(2800, "kJ/kg"), S=Q(7300, "J/kg/K"))
-# <Water (Gas), P=225 kPa, T=165.8 °C, D=1.1 kg/m³, V=0.0 cP>
+# <Water (Gas), P=225 kPa, T=165.8 °C, D=1.1 kg/m³, V=0.015 cP>
 ```
 
 Mixtures are given either by fractions folded into the name or by a `composition` dict of mole fractions.
@@ -324,16 +323,17 @@ Each `fluid(...)` / `humid_air(...)` is an independent plugin node, so selecting
 To load additional methods for the `sympy.Symbol` class, import Sympy via the `encomp.sympy` module. The `_` / `__` methods add typeset sub- and superscripts, and quantities combine directly with symbols:
 
 ```python
+from typing import Any, cast
+
 from encomp.sympy import sp
 from encomp.units import Quantity as Q
 
 n = sp.Symbol("n", integer=True)
 
 # the _ / __ methods are added to sp.Symbol at runtime by encomp.sympy
-# pyrefly: ignore[missing-attribute]
-n._("H_2O").__("out")  # n_{\text{H}_2\text{O}}^{\text{out}}, keeps the integer assumption
+cast(Any, n)._("H_2O").__("out")  # n_{\text{H}_2\text{O}}^{\text{out}}, keeps the integer assumption
 
-x, y, z = sp.symbols("x, y, z")
+x, y, z = sp.symbols("x, y, z")  # pyright: ignore[reportUnknownMemberType]
 result_expr = (25 * x * y / z).subs({x: Q(235, "yard"), y: Q(2, "m²"), z: Q(0.4, "m³/kg")})
 Q.from_expr(result_expr)  # ≈ 26860.5 kg
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,6 +13,7 @@ guide, example notebooks, and API reference are linked in the toctree below.
 :maxdepth: 3
 
 usage
+release-notes
 examples
 api
 ```

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,0 +1,13 @@
+# Release Notes
+
+## 1.6.1
+
+This patch release fixes issues found after 1.6.0.
+
+- Hardened `Quantity` runtime validation so subscripted constructors and the `.m` setter reject string, `None`, and non-1D magnitudes, and normalize numpy array magnitudes to `float64`.
+- Fixed in-place `*=`, `/=`, `//=`, and `**=` so ndarray-backed quantities rebuild the correct dimensionality subclass instead of mutating into an inconsistent runtime type.
+- Restored pickling for quantities with dynamically derived, unregistered dimensionalities.
+- Fixed CoolProp expression handling for invalid input pairs, duplicate/synonym state inputs, scalar literals on empty frames, and invalid plugin inputs so they raise Python/Polars exceptions instead of panicking or returning silent nulls.
+- Interpreted basis-percent unit spellings such as `mol%`, `mol-%`, `kg%`, `m3%`, and `vol%` as dimensionless percent values.
+- Made gas condition literal support consistent across gas conversion helpers.
+- Updated docs and CI so documentation snippets type-check under `pyright` from a source checkout.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -48,15 +48,17 @@ It is based on the `defaults_en.txt` file from `pint`, with minor modifications.
 Quantities can also be constructed from unit registry attributes:
 
 ```python
+from typing import Any, cast
+
 from encomp.units import UNIT_REGISTRY
 from encomp.units import Quantity as Q
 
 # the registry attributes are typed for use as Quantity units, not for
-# direct arithmetic, so these operations need pyrefly suppressions
-d = 50 * UNIT_REGISTRY.m  # pyrefly: ignore[unsupported-operation]
-v = d / UNIT_REGISTRY.s  # pyrefly: ignore[unsupported-operation]
+# direct arithmetic, so annotate intermediate values as dynamic.
+d: Any = cast(Any, 50 * UNIT_REGISTRY.m)
+v: Any = d / UNIT_REGISTRY.s
 
-mf = Q(25, UNIT_REGISTRY.kg / UNIT_REGISTRY.h)  # pyrefly: ignore[unsupported-operation]
+mf = Q(25, cast(Any, UNIT_REGISTRY.kg / UNIT_REGISTRY.h))
 ```
 
 ### Quantity types
@@ -157,10 +159,8 @@ Q(1, "delta_degC").check(Temperature)  # True
 # alternative using isinstance()
 # (parameterized isinstance is a runtime-only feature, hence the suppressions)
 
-# pyrefly: ignore[invalid-argument]
-isinstance(pressure, Q[Pressure])  # True
-# pyrefly: ignore[invalid-argument]
-isinstance(pressure, Q[Length])  # False
+isinstance(pressure, Q[Pressure])  # True  # pyright: ignore[reportArgumentType, reportUnnecessaryIsInstance]
+isinstance(pressure, Q[Length])  # False  # pyright: ignore[reportArgumentType, reportUnnecessaryIsInstance]
 
 # complex types must use isinstance_types
 # this function can also be used with simple types
@@ -182,7 +182,7 @@ from encomp.utypes import Length, Power, Pressure
 
 
 @typechecked
-def func(_p1: Q[Pressure]) -> tuple[Q[Length], Q[Power]]:
+def func(_p1: Q[Pressure, float]) -> tuple[Q[Length, float], Q[Power, float]]:
     return Q(1, "m"), Q(1, "kW")
 ```
 
@@ -356,7 +356,7 @@ from encomp.utypes import Pressure
 
 try:
     # a static type checker rejects this addition as well
-    Q(25, "bar") + Q(25, "m")  # pyrefly: ignore[unsupported-operation]
+    Q(25, "bar") + Q(25, "m")  # pyright: ignore[reportOperatorIssue]
 except DimensionalityError as e:
     print(f"Error: {e}")
 
@@ -376,6 +376,8 @@ except DimensionalityError as e:
 {py:class}`encomp.units.Quantity` (optionally with a dimensionality type parameter) works as a Pydantic field type.
 
 ```python
+from typing import Any, cast
+
 from pydantic import BaseModel, ConfigDict, TypeAdapter, ValidationError
 
 from encomp.units import Quantity as Q
@@ -386,10 +388,10 @@ class Model(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True, validate_default=True)
 
     # a can be any dimensionality
-    a: Q
+    a: Q[Any, Any]
 
-    m: Q[Mass]
-    s: Q[Length]
+    m: Q[Mass, float]
+    s: Q[Length, float]
 
     # float is converted to Quantity[Dimensionless]
     r: Q[Dimensionless, float] = Q(0.5)
@@ -404,7 +406,7 @@ adapter = TypeAdapter(Q[Mass, float])
 adapter.validate_json(adapter.dump_json(Q(2.0, "kg")))
 
 try:
-    Model(a=Q(25, "cSt"), m=Q(25, "m"), s=Q(25, "cm"))
+    Model(a=Q(25, "cSt"), m=cast(Any, Q(25, "m")), s=Q(25, "cm"))
 except ValidationError as e:
     print(e.errors()[0]["type"])  # quantity_dimensionality
 ```
@@ -458,7 +460,7 @@ from encomp.units import Quantity as Q
 
 # input units are converted to SI
 Water(P=Q(30, "psi"), T=Q(250, "°F"))
-# <Water (Liquid), P=207 kPa, T=121.1 °C, D=942.2 kg/m³, V=0.2 cP>
+# <Water (Liquid), P=207 kPa, T=121.1 °C, D=942.2 kg/m³, V=0.23 cP>
 
 HumidAir(T=Q(25, "°C"), P=Q(2, "bar"), R=Q(25, "%"))
 # <HumidAir, P=200 kPa, T=25.0 °C, R=0.25, Vda=0.4 m³/kg, Vha=0.4 m³/kg, M=0.018 cP>
@@ -513,7 +515,7 @@ Water.describe("PCRIT")
 water = Water(T=Q(25, "°C"), P=Q(1, "atm"))
 
 critical = water.p_critical, water.PCRIT
-# (22064000.0 <Unit('pascal')>, 22064000.0 <Unit('pascal')>)
+# (<Quantity(22064.0, 'kilopascal')>, <Quantity(22064.0, 'kilopascal')>)
 ```
 
 :::{tip}
@@ -568,7 +570,7 @@ from encomp.units import Quantity as Q
 Water(T=Q(np.linspace(25, 50, 10), "°C"), P=Q(np.linspace(25, 50, 10), "bar"))
 # the repr shows only the head of each vector input
 # <Water (Liquid), P=[2500 2778 3056 ...] kPa, T=[25.0 27.8 30.6 ...] °C,
-# D=[998.1 997.5 996.8 ...] kg/m³, V=[0.9 0.8 0.8 ...] cP>
+# D=[998.1 997.5 996.8 ...] kg/m³, V=[0.89 0.84 0.79 ...] cP>
 
 # different phases
 phases = Water(T=Q(np.linspace(25, 500, 10), "°C"), P=Q(np.linspace(0.5, 10, 10), "bar")).PHASE
@@ -589,7 +591,7 @@ phase_names = Water.PHASES
 # it's repeated as an array
 Water(T=Q(np.linspace(25, 500, 10), "°C"), P=Q(5, "bar"))
 # <Water (Variable), P=[500 500 500 ...] kPa, T=[25.0 77.8 130.6 ...] °C,
-# D=[997.2 973.4 934.5 ...] kg/m³, V=[0.9 0.4 0.2 ...] cP>
+# D=[997.2 973.4 934.5 ...] kg/m³, V=[0.89 0.36 0.21 ...] cP>
 ```
 
 Missing or out-of-range results surface as `NaN` (for a numpy magnitude) or `null` (for a Polars magnitude), never as a zero or a raised exception, so a partly-invalid batch still returns the valid rows.
@@ -648,12 +650,14 @@ The following convenience methods are added to the `sp.Symbol` class:
 These methods return new `sp.Symbol` instances with the same assumptions (*positive*, *real*, *integer*, ...) as the original.
 
 ```python
+from typing import Any, cast
+
 from encomp.sympy import sp
 
 n = sp.Symbol("n", integer=True)
 
 # the _ method is added to sp.Symbol at runtime by encomp.sympy
-n_test = n._("test")  # pyrefly: ignore[missing-attribute]
+n_test: Any = cast(Any, n)._("test")
 str(n_test)
 # n_{\text{test}}
 
@@ -686,7 +690,7 @@ The class method {py:meth}`encomp.units.Quantity.from_expr` converts an expressi
 from encomp.sympy import sp
 from encomp.units import Quantity as Q
 
-x, y, z = sp.symbols("x, y, z")
+x, y, z = sp.symbols("x, y, z")  # pyright: ignore[reportUnknownMemberType]
 
 expr = 25 * x * y / z
 
@@ -711,7 +715,7 @@ import numpy as np
 from encomp.sympy import get_function, sp
 from encomp.units import Quantity as Q
 
-x, y, z = sp.symbols("x, y, z")
+x, y, z = sp.symbols("x, y, z")  # pyright: ignore[reportUnknownMemberType]
 
 expr = 25 * x * y / z
 
@@ -734,7 +738,7 @@ Quantity objects combine directly with Sympy symbols; the units are converted to
 from encomp.sympy import sp
 from encomp.units import Quantity as Q
 
-x, y, z = sp.symbols("x, y, z")
+x, y, z = sp.symbols("x, y, z")  # pyright: ignore[reportUnknownMemberType]
 
 # the type of the left object determines the output
 

--- a/encomp/conversion.py
+++ b/encomp/conversion.py
@@ -1,8 +1,11 @@
-from typing import Any, overload
+from typing import Any, cast, overload
+
+import numpy as np
+import polars as pl
 
 from .misc import isinstance_types
 from .units import ExpectedDimensionalityError, Quantity
-from .utypes import MT, Density, Mass, MassFlow, Volume, VolumeFlow
+from .utypes import MT, Density, Mass, MassFlow, Numpy1DArray, Volume, VolumeFlow
 
 
 @overload
@@ -57,6 +60,19 @@ def convert_volume_mass(
 
     if not isinstance_types(rho, Quantity[Density, Any]):
         raise ExpectedDimensionalityError(f"rho must be a Quantity[Density], passed {rho!r} ({type(rho).__name__})")
+
+    rho_m = rho.to("kg/m³").m
+    if isinstance(rho_m, float):
+        if not np.isfinite(rho_m) or rho_m <= 0.0:
+            raise ValueError(f"rho must be finite and positive, got {rho!r}")
+    elif isinstance(rho_m, np.ndarray):
+        rho_arr = cast("Numpy1DArray", rho_m)
+        if bool(np.any(~np.isfinite(rho_arr) | (rho_arr <= 0.0))):
+            raise ValueError(f"rho must contain only finite positive values, got {rho!r}")
+    elif isinstance(rho_m, pl.Series):
+        valid = rho_m.is_finite() & (rho_m > 0.0)
+        if not valid.all():
+            raise ValueError(f"rho must contain only finite positive values, got {rho!r}")
 
     if isinstance_types(inp, Quantity[Mass, Any]):
         return (inp / rho).to_reduced_units().asdim(Volume)

--- a/encomp/coolprop/README.md
+++ b/encomp/coolprop/README.md
@@ -95,9 +95,9 @@ much slower per call (iterative solver). Still better than the Python path.
   (bumping `pyo3-polars` to the new Rust polars) is needed only if polars bumps the ffi
   ABI **major** — rare and announced. `self_check()` evaluates a known value at first use,
   so a genuinely incompatible polars surfaces as a clear error, never a silent wrong result.
-- **Version match**: CoolProp enum integers differ across versions; pin Python
-  `coolprop==8.0.0` to match the bundled Rust lib. The plugin resolves parameter
-  indices via CoolProp at runtime, never hardcoded.
+- **Version match**: CoolProp enum integers can differ across major versions. `encomp`
+  requires Python `coolprop>=8.0.0,<9`, while the bundled Rust lib is built at 8.0.0.
+  The plugin resolves parameter indices via CoolProp at runtime, never hardcoded.
 - **One property per node (no output batching).** Each `fluid(...)` / `humid_air(...)` is an
   independent plugin node, so selecting K properties of one state runs K flashes of it —
   Polars cannot reuse (CSE) the shared flash across opaque plugin nodes. Independent
@@ -122,7 +122,7 @@ via `.github/workflows/release.yml`:
 
 | target  | on this macOS host         | in CI                                  |
 |---------|----------------------------|----------------------------------------|
-| macOS   | yes (native)               | macos-13 (x86_64), macos-14 (arm64)    |
+| macOS   | yes (native)               | macos-14 (arm64)                       |
 | Linux   | yes, via Docker (manylinux)| ubuntu (x86_64) + ubuntu-arm (aarch64) |
 | Windows | no — needs Windows         | windows-latest (amd64)                 |
 

--- a/encomp/coolprop/__init__.py
+++ b/encomp/coolprop/__init__.py
@@ -74,6 +74,7 @@ __all__ = [
     "lib_path",
     "lib_version",
     "resolve_fluid_spec",
+    "self_check",
 ]
 
 # Each name set is defined ONCE as a Literal (static typing) and exposed as a
@@ -456,6 +457,8 @@ def _resolve_pair(name1: str, name2: str) -> tuple[int, bool]:
     # CoolProp's generate_update_pair gives the canonical input_pairs index and
     # value order; the swap decision is value-independent, so resolve it once.
     pair, a, _ = _cp.generate_update_pair(_cp.get_parameter_index(name1), 1.0, _cp.get_parameter_index(name2), 2.0)
+    if int(pair) == 0:
+        raise ValueError(f"unsupported CoolProp input pair: {name1!r}, {name2!r}")
     return int(pair), (a == 2.0)
 
 

--- a/encomp/defs/units.txt
+++ b/encomp/defs/units.txt
@@ -109,6 +109,7 @@ candela = [luminosity] = cd = candle
 gram = [mass] = g
 mole = [substance] = mol
 kelvin = [temperature]; offset: 0 = K = degK = °K = degree_Kelvin = degreeK  # older names supported for compatibility
+delta_kelvin = kelvin = delta_K
 radian = [] = rad
 bit = []
 count = []

--- a/encomp/fluids.py
+++ b/encomp/fluids.py
@@ -665,6 +665,15 @@ class CoolPropFluid(ABC, Generic[MT]):  # noqa: UP046
                 f"Valid state inputs:\n{', '.join(sorted(cls.STATE_INPUTS))}"
             )
 
+        seen: dict[tuple[CProperty, ...], str] = {}
+        for key in kwargs:
+            prop_key = cls.get_prop_key(key)
+            if previous := seen.get(prop_key):
+                raise ValueError(
+                    f"{cls.__name__} inputs must be distinct; got {previous!r} and {key!r} for the same state input"
+                )
+            seen[prop_key] = key
+
     def _build_points(
         self, kwargs: Mapping[str, object]
     ) -> list[tuple[CProperty, Quantity[Any, MT] | Quantity[Any, float]]]:

--- a/encomp/fluids.py
+++ b/encomp/fluids.py
@@ -294,7 +294,6 @@ class CoolPropFluid(ABC, Generic[MT]):  # noqa: UP046
         "Brent's method f(b) is NAN",
         "do not bracket the root",
         "was unable to find a solution for",
-        "is outside the range of validity",
     )
 
     PHASES: dict[float, str] = {
@@ -728,7 +727,7 @@ class CoolPropFluid(ABC, Generic[MT]):  # noqa: UP046
         # this error occurs in case the input values are outside
         # the allowable range for this property
         # in this case the return value will be NaN, no exception is raised
-        if "No outputs were able to be calculated" in msg or "is outside the range of validity" in msg:
+        if "No outputs were able to be calculated" in msg:
             self._warn_coolprop_nan(prop, msg)
             return
 

--- a/encomp/gases.py
+++ b/encomp/gases.py
@@ -274,7 +274,7 @@ def mass_to_normal_volume(
 @overload
 def mass_to_actual_volume(
     mass: Quantity[Mass, MT],
-    condition: tuple[Quantity[Pressure, Any], Quantity[Temperature, Any]],
+    condition: GasConditionInput,
     fluid_name: str = "Air",
 ) -> Quantity[Volume, MT]: ...
 
@@ -282,14 +282,14 @@ def mass_to_actual_volume(
 @overload
 def mass_to_actual_volume(
     mass: Quantity[MassFlow, MT],
-    condition: tuple[Quantity[Pressure, Any], Quantity[Temperature, Any]],
+    condition: GasConditionInput,
     fluid_name: str = "Air",
 ) -> Quantity[VolumeFlow, MT]: ...
 
 
 def mass_to_actual_volume(
     mass: Quantity[Mass, Any] | Quantity[MassFlow, Any],
-    condition: tuple[Quantity[Pressure, Any], Quantity[Temperature, Any]],
+    condition: GasConditionInput,
     fluid_name: str = "Air",
 ) -> Quantity[Volume, Any] | Quantity[VolumeFlow, Any]:
     """
@@ -299,7 +299,7 @@ def mass_to_actual_volume(
     ----------
     mass : Quantity[Mass, MT] | Quantity[MassFlow, MT]
         Input mass or mass flow
-    condition : tuple[Quantity[Pressure, Any], Quantity[Temperature, Any]]
+    condition : tuple[Quantity[Pressure, Any], Quantity[Temperature, Any]] | Literal['N', 'S']
         Condition at which to calculate the actual volume
     fluid_name : str, optional
         Name of the fluid, by default 'Air'
@@ -310,7 +310,8 @@ def mass_to_actual_volume(
         Corresponding actual volume or actual volume flow
     """
 
-    rho = Fluid(fluid_name, P=condition[0], T=condition[1]).D
+    P, T = _resolve_gas_condition(condition, "condition")
+    rho = Fluid(fluid_name, P=P, T=T).D
 
     ret = convert_volume_mass(mass, rho=rho)
 
@@ -370,7 +371,7 @@ def mass_from_normal_volume(
 @overload
 def mass_from_actual_volume(
     volume: Quantity[Volume, MT],
-    condition: tuple[Quantity[Pressure, Any], Quantity[Temperature, Any]],
+    condition: GasConditionInput,
     fluid_name: str = "Air",
 ) -> Quantity[Mass, MT]: ...
 
@@ -378,14 +379,14 @@ def mass_from_actual_volume(
 @overload
 def mass_from_actual_volume(
     volume: Quantity[VolumeFlow, MT],
-    condition: tuple[Quantity[Pressure, Any], Quantity[Temperature, Any]],
+    condition: GasConditionInput,
     fluid_name: str = "Air",
 ) -> Quantity[MassFlow, MT]: ...
 
 
 def mass_from_actual_volume(
     volume: Quantity[Volume, Any] | Quantity[VolumeFlow, Any],
-    condition: tuple[Quantity[Pressure, Any], Quantity[Temperature, Any]],
+    condition: GasConditionInput,
     fluid_name: str = "Air",
 ) -> Quantity[Mass, Any] | Quantity[MassFlow, Any]:
     """
@@ -395,7 +396,7 @@ def mass_from_actual_volume(
     ----------
     volume : Quantity[Volume, MT] | Quantity[VolumeFlow, MT]
         Input actual volume or actual volume flow
-    condition : tuple[Quantity[Pressure, Any], Quantity[Temperature, Any]]
+    condition : tuple[Quantity[Pressure, Any], Quantity[Temperature, Any]] | Literal['N', 'S']
         Condition at which to calculate the mass
     fluid_name : str, optional
         Name of the fluid, by default 'Air'
@@ -406,7 +407,8 @@ def mass_from_actual_volume(
         Corresponding mass or mass flow
     """
 
-    rho = Fluid(fluid_name, P=condition[0], T=condition[1]).D
+    P, T = _resolve_gas_condition(condition, "condition")
+    rho = Fluid(fluid_name, P=P, T=T).D
 
     ret = convert_volume_mass(volume, rho=rho)
 
@@ -416,7 +418,7 @@ def mass_from_actual_volume(
 @overload
 def actual_volume_to_normal_volume(
     volume: Quantity[Volume, Any],
-    condition: tuple[Quantity[Pressure, Any], Quantity[Temperature, Any]],
+    condition: GasConditionInput,
     fluid_name: str = "Air",
 ) -> Quantity[NormalVolume, Any]: ...
 
@@ -424,14 +426,14 @@ def actual_volume_to_normal_volume(
 @overload
 def actual_volume_to_normal_volume(
     volume: Quantity[VolumeFlow, Any],
-    condition: tuple[Quantity[Pressure, Any], Quantity[Temperature, Any]],
+    condition: GasConditionInput,
     fluid_name: str = "Air",
 ) -> Quantity[NormalVolumeFlow, Any]: ...
 
 
 def actual_volume_to_normal_volume(
     volume: Quantity[Volume, Any] | Quantity[VolumeFlow, Any],
-    condition: tuple[Quantity[Pressure, Any], Quantity[Temperature, Any]],
+    condition: GasConditionInput,
     fluid_name: str = "Air",
 ) -> Quantity[NormalVolume, Any] | Quantity[NormalVolumeFlow, Any]:
     """
@@ -441,7 +443,7 @@ def actual_volume_to_normal_volume(
     ----------
     volume : Quantity[Volume, Any] | Quantity[VolumeFlow, Any]
         Input actual volume or actual volume flow
-    condition : tuple[Quantity[Pressure, Any], Quantity[Temperature, Any]]
+    condition : tuple[Quantity[Pressure, Any], Quantity[Temperature, Any]] | Literal['N', 'S']
         Condition at which the input volume is evaluated
     fluid_name : str, optional
         Name of the fluid, by default 'Air'
@@ -460,7 +462,7 @@ def actual_volume_to_normal_volume(
 @overload
 def normal_volume_to_actual_volume(
     volume: Quantity[NormalVolume, Any],
-    condition: tuple[Quantity[Pressure, Any], Quantity[Temperature, Any]],
+    condition: GasConditionInput,
     fluid_name: str = "Air",
 ) -> Quantity[Volume, Any]: ...
 
@@ -468,7 +470,7 @@ def normal_volume_to_actual_volume(
 @overload
 def normal_volume_to_actual_volume(
     volume: Quantity[NormalVolumeFlow, Any],
-    condition: tuple[Quantity[Pressure, Any], Quantity[Temperature, Any]],
+    condition: GasConditionInput,
     fluid_name: str = "Air",
 ) -> Quantity[VolumeFlow, Any]: ...
 
@@ -480,7 +482,7 @@ def normal_volume_to_actual_volume(
         | Quantity[Volume, Any]
         | Quantity[VolumeFlow, Any]
     ),
-    condition: tuple[Quantity[Pressure, Any], Quantity[Temperature, Any]],
+    condition: GasConditionInput,
     fluid_name: str = "Air",
 ) -> Quantity[Volume, Any] | Quantity[VolumeFlow, Any]:
     """
@@ -494,7 +496,7 @@ def normal_volume_to_actual_volume(
     ----------
     volume : Quantity[NormalVolume, Any] | Quantity[NormalVolumeFlow, Any]
         Input normal volume or normal volume flow
-    condition : tuple[Quantity[Pressure, Any], Quantity[Temperature, Any]]
+    condition : tuple[Quantity[Pressure, Any], Quantity[Temperature, Any]] | Literal['N', 'S']
         Condition at which to calculate the actual volume
     fluid_name : str, optional
         Name of the fluid, by default 'Air'

--- a/encomp/misc.py
+++ b/encomp/misc.py
@@ -1,6 +1,6 @@
 import ast
 from types import UnionType
-from typing import Any, TypeIs, cast, get_args, get_origin
+from typing import Any, TypeIs, Union, cast, get_args, get_origin
 
 from typeguard import TypeCheckError, check_type
 from typing_extensions import TypeForm
@@ -22,12 +22,14 @@ def isinstance_types[T](obj: Any, expected: TypeForm[T]) -> TypeIs[T]:  # noqa: 
     if isinstance(expected, str):
         raise TypeError(f"expected must be a type or type form, not a string: {expected!r}")
 
-    if get_origin(expected) is UnionType:
+    origin = get_origin(expected)
+
+    if origin in (UnionType, Union):
         # a Quantity must be routed through the detailed per-member logic below: a plain
         # isinstance against the union misclassifies a Quantity[UnknownDimensionality, ...]
         # member (it matches ANY dimensionality here, but is a *sibling* class at runtime, so
         # isinstance says False) -- decompose so single-type and union checks stay consistent.
-        if not isinstance(obj, Quantity):
+        if not isinstance(obj, Quantity) and origin is UnionType:
             # narrowed to a UnionType by the check above, which isinstance accepts
             try:
                 return isinstance(obj, cast(UnionType, expected))

--- a/encomp/structures.py
+++ b/encomp/structures.py
@@ -39,21 +39,23 @@ def divide_chunks(container: Any, N: int) -> Any:
     return _chunks()
 
 
-def flatten(container: Iterable[Any], max_depth: int | None = None, _depth: int = 0) -> Iterator[Any]:
-    if max_depth is not None and _depth >= max_depth:
-        yield container
-        return
+def flatten(container: Iterable[Any], max_depth: int | None = None) -> Iterator[Any]:
+    def _flatten(items: Iterable[Any], depth: int) -> Iterator[Any]:
+        if max_depth is not None and depth >= max_depth:
+            yield items
+            return
 
-    for obj in container:
-        # atomic despite being iterable: iterating a dict would silently drop its
-        # values (keys only), and bytes would flatten into individual integers
-        if isinstance(obj, (str, bytes, dict, Quantity, np.ndarray, pl.Series, pl.Expr)):
+        for obj in items:
+            # atomic despite being iterable: iterating a dict would silently drop its
+            # values (keys only), and bytes would flatten into individual integers
+            if isinstance(obj, (str, bytes, dict, Quantity, np.ndarray, pl.Series, pl.Expr)):
+                yield obj
+                continue
+
+            if isinstance(obj, Iterable):
+                yield from _flatten(cast("Iterable[Any]", obj), depth + 1)  # pyrefly: ignore[redundant-cast]  # cast required by pyright
+                continue
+
             yield obj
-            continue
 
-        if isinstance(obj, Iterable):
-            yield from flatten(cast("Iterable[Any]", obj), max_depth=max_depth, _depth=_depth + 1)  # pyrefly: ignore[redundant-cast]  # cast required by pyright
-
-            continue
-
-        yield obj
+    yield from _flatten(container, 0)

--- a/encomp/sympy.py
+++ b/encomp/sympy.py
@@ -434,9 +434,8 @@ def get_function(e: sp.Basic, *, units: bool = False) -> Callable[[dict[Any, Any
     Returns
     -------
     Callable
-        Function that evaluates the input expression, can be called
-        with extra kwargs. The kwargs can be a dict with mapping
-        from symbol to value.
+        Function that evaluates the input expression from a mapping of
+        symbols to values.
     """
 
     fcn, args = get_lambda(e)

--- a/encomp/sympy.py
+++ b/encomp/sympy.py
@@ -271,7 +271,7 @@ def get_lambda_kwargs(
     include: Sequence[sp.Symbol | str] | None = None,
     *,
     units: bool = False,
-) -> dict[str, Quantity | np.ndarray]:
+) -> dict[str, Quantity | np.ndarray | float]:
     """
     Returns a mapping from identifier to value (Quantity or float)
     based on the input value map (Symbol to value).
@@ -298,7 +298,7 @@ def get_lambda_kwargs(
 
     def _get_val(
         x: Quantity[Any, Numpy1DArray] | Numpy1DArray,
-    ) -> Quantity | Numpy1DArray:
+    ) -> Quantity | Numpy1DArray | float:
         if not isinstance(x, Quantity):
             return x
 
@@ -452,7 +452,7 @@ def evaluate(
     value_map: dict[sp.Symbol, Quantity | np.ndarray],
     *,
     units: bool = False,
-) -> Quantity | np.ndarray:
+) -> Quantity | np.ndarray | float:
     """
     Evaluates the input expression, given the mapping of symbol to
     value in ``value_map``.
@@ -476,7 +476,7 @@ def evaluate(
     """
 
     fcn = get_function(e, units=units)
-    return cast(Quantity | np.ndarray, fcn(value_map))
+    return cast(Quantity | np.ndarray | float, fcn(value_map))
 
 
 def substitute_unknowns(

--- a/encomp/tests/test_conversion.py
+++ b/encomp/tests/test_conversion.py
@@ -1,10 +1,8 @@
 from typing import Any, assert_type, cast
 
-import numpy as np
 import pytest
 
 from ..conversion import convert_volume_mass
-from ..misc import isinstance_types
 from ..units import ExpectedDimensionalityError
 from ..units import Quantity as Q
 from ..utypes import Numpy1DArray, Volume, VolumeFlow
@@ -23,23 +21,28 @@ assert_type.__code__ = _assert_type.__code__
 def test_convert_volume_mass() -> None:
     mf = Q(25, "kg/s")
 
-    assert isinstance_types(convert_volume_mass(mf), Q[VolumeFlow])
     assert_type(convert_volume_mass(mf), Q[VolumeFlow, float])
-    assert not isinstance_types(convert_volume_mass(mf), Q[VolumeFlow, np.ndarray])
 
     mf_list = Q([25.5, 25.34], "kg/s")
-    assert isinstance_types(convert_volume_mass(mf_list), Q[VolumeFlow])
-
     assert_type(convert_volume_mass(mf_list), Q[VolumeFlow, Numpy1DArray])
 
     m = Q(25, "ton")
 
-    assert isinstance_types(convert_volume_mass(m), Q[Volume])
+    assert_type(convert_volume_mass(m), Q[Volume, float])
 
     # wrong dimensionality raises a proper unit error naming the argument,
     # not an internal AssertionError
     with pytest.raises(ExpectedDimensionalityError, match="rho"):
         convert_volume_mass(mf, rho=cast(Any, Q(25, "bar")))
+
+    with pytest.raises(ValueError, match="positive"):
+        convert_volume_mass(mf, rho=Q(0, "kg/m³"))
+
+    with pytest.raises(ValueError, match="positive"):
+        convert_volume_mass(mf, rho=Q(-1, "kg/m³"))
+
+    with pytest.raises(ValueError, match="positive"):
+        convert_volume_mass(mf_list, rho=Q([997.0, 0.0], "kg/m³"))
 
     with pytest.raises(ExpectedDimensionalityError, match="inp"):
         convert_volume_mass(cast(Any, Q(25, "m/s")))

--- a/encomp/tests/test_coolprop_plugin.py
+++ b/encomp/tests/test_coolprop_plugin.py
@@ -333,6 +333,21 @@ def test_input_not_named_after_state_input_raises() -> None:
         cp.humid_air("W", pl.col("rel_hum"), "T", "P")
 
 
+def test_invalid_input_pair_raises_before_plugin_execution() -> None:
+    with pytest.raises(ValueError, match="unsupported CoolProp input pair"):
+        cp.fluid("DMASS", "H", "U")
+
+
+def test_invalid_runtime_names_raise_python_exceptions() -> None:
+    df = pl.DataFrame({"P": [101325.0], "T": [300.0]})
+
+    with pytest.raises(Exception, match="unknown parameter"):
+        df.select(cp.fluid(cast(Any, "NOT_A_PROPERTY"), "P", "T"))
+
+    with pytest.raises(Exception, match="interior NUL"):
+        df.select(cp.fluid("DMASS", "P", "T", name=cast(Any, "Water\0bad")))
+
+
 def test_duplicate_state_inputs_raise() -> None:
     with pytest.raises(ValueError, match="distinct"):
         cp.fluid("DMASS", "P", "P")
@@ -345,6 +360,18 @@ def test_duplicate_state_inputs_raise() -> None:
 
     with pytest.raises(ValueError, match="same state input"):
         cp.humid_air("W", "P", "R", "RH")
+
+
+def test_scalar_literal_inputs_on_empty_frames_return_empty() -> None:
+    df = pl.DataFrame({"T": pl.Series([], dtype=pl.Float64)})
+    out = df.select(cp.fluid("DMASS", pl.lit(5e5).alias("P"), "T", name="HEOS::Water").alias("d"))
+    assert out.height == 0
+    assert out["d"].null_count() == 0
+
+    humid = pl.DataFrame({"T": pl.Series([], dtype=pl.Float64), "R": pl.Series([], dtype=pl.Float64)})
+    humid_out = humid.select(cp.humid_air("W", pl.lit(101325.0).alias("P"), "T", "R").alias("w"))
+    assert humid_out.height == 0
+    assert humid_out["w"].null_count() == 0
 
 
 def test_fluid_composition_validation_matches_fluids() -> None:

--- a/encomp/tests/test_docs.py
+++ b/encomp/tests/test_docs.py
@@ -30,7 +30,10 @@ Checks per block:
   A subprocess (not in-process ``exec``) is required for the ``typeguard`` examples --
   ``@typechecked`` instruments by re-reading the module source, which does not exist for
   exec'd strings -- and the temporary cwd lets blocks create scratch files (e.g. the
-  ``.env`` example) without touching the repo.
+  ``.env`` example) without touching the repo. Native ``encomp.coolprop`` plugin
+  examples are also linted and type-checked here, but their execution is skipped when
+  the compiled extension is not present in this source-only environment; wheel CI runs
+  the plugin self-check and the full test suite against the built wheels.
 
 There is deliberately no opt-out: a snippet that cannot run as written (for example one
 that demonstrates an exception) shows the failure with ``try: ... except SomeError:``
@@ -48,6 +51,7 @@ import re
 import shutil
 import subprocess
 import sys
+from functools import lru_cache
 from pathlib import Path
 
 import pytest
@@ -92,6 +96,13 @@ _SKIP_DIRS = {
     "temp",
 }
 _SKIP_FILES = {"REVIEW.md"}
+_COOLPROP_PLUGIN_MARKERS = (
+    "from encomp import coolprop",
+    "from encomp.coolprop import",
+    "import encomp.coolprop",
+    "cp.fluid(",
+    "cp.humid_air(",
+)
 
 
 def _doc_files(root: Path) -> list[Path]:
@@ -114,6 +125,20 @@ def _blocks() -> list[tuple[str, str]]:
             line = text[: m.start()].count("\n") + 1
             cases.append((f"{md.relative_to(ROOT)}:{line}", code))
     return cases
+
+
+def _requires_coolprop_plugin(code: str) -> bool:
+    return any(marker in code for marker in _COOLPROP_PLUGIN_MARKERS)
+
+
+@lru_cache(maxsize=1)
+def _coolprop_plugin_available() -> bool:
+    try:
+        from encomp import coolprop as cp
+    except Exception:
+        return False
+
+    return cp.self_check()
 
 
 _CASES = _blocks()
@@ -160,6 +185,9 @@ def test_doc_block_typechecks(code: str, tmp_path: Path) -> None:
 @pytest.mark.parametrize("code", _CODES, ids=_IDS)
 def test_doc_block_runs(code: str, tmp_path: Path) -> None:
     assert ROOT is not None  # narrowed by the module-level skipif
+    if _requires_coolprop_plugin(code) and not _coolprop_plugin_available():
+        pytest.skip("compiled encomp.coolprop plugin is not available")
+
     block = tmp_path / "block.py"
     block.write_text(code)
     env = {

--- a/encomp/tests/test_docs.py
+++ b/encomp/tests/test_docs.py
@@ -102,6 +102,7 @@ _COOLPROP_PLUGIN_MARKERS = (
     "import encomp.coolprop",
     "cp.fluid(",
     "cp.humid_air(",
+    "Q(pl.col(",
 )
 
 

--- a/encomp/tests/test_docs.py
+++ b/encomp/tests/test_docs.py
@@ -1,5 +1,5 @@
 """Every ``python`` code block in the docs must be self-contained: it carries its own
-imports, is clean under ``ruff check``, type-checks under ``pyrefly``, and runs without
+imports, is clean under ``ruff check``, type-checks under ``pyright``, and runs without
 error in isolation.
 
 This guards the documentation against drift -- a renamed API, a missing import, or a
@@ -16,15 +16,15 @@ Checks per block:
 - ``ruff check`` under the repo's full ruff config (run with cwd at the repo root), so each
   block is held to the same ruleset as the source (imports, naming, bugbear, ...) with no
   per-block exceptions -- ``F401`` (unused import) and ``F821`` (undefined name) both gate.
-- ``pyrefly check`` against the repo config (``--config`` is passed explicitly: without
-  it, pyrefly silently skips files outside a configured project and reports "0 errors"
-  without analyzing anything). A type error in an example is a real defect to fix --
-  ``Q(1, "bar")`` infers ``Quantity[Pressure, float]``, so a correct block is clean.
-  Blocks that demonstrate runtime-only dynamic behavior (parameterized ``isinstance``,
-  the sympy ``_``/``__`` methods added at import time, deliberately-invalid operations
-  shown inside ``try``/``except``) carry explicit ``# pyrefly: ignore[...]`` comments;
-  the repo config elevates ``unused-ignore`` to an error, so a suppression that stops
-  matching real errors fails this test instead of lingering.
+- ``pyright`` against the repo config (``--project`` is passed explicitly so temp files
+  are checked with the same strict settings as the source tree). A type error in an
+  example is a real defect to fix -- ``Q(1, "bar")`` infers
+  ``Quantity[Pressure, float]``, so a correct block is clean. Blocks that demonstrate
+  runtime-only dynamic behavior (parameterized ``isinstance``, the sympy ``_``/``__``
+  methods added at import time, deliberately-invalid operations shown inside
+  ``try``/``except``) carry explicit ``# pyright: ignore[...]`` comments. The test
+  disables ``reportUnusedExpression`` for snippets because docs naturally include
+  REPL-style expressions followed by comments showing their value.
 - execution as a real script: the block is written to a file and run in a fresh
   interpreter with a temporary working directory, exactly as a reader would run it.
   A subprocess (not in-process ``exec``) is required for the ``typeguard`` examples --
@@ -38,11 +38,12 @@ instead, so it still executes.
 
 The whole module skips when the repo docs are not on disk (e.g. running from an installed
 wheel via ``pytest --pyargs encomp.tests``); it is a source-tree / CI check. Individual
-tool checks skip if ``ruff`` / ``pyrefly`` are not installed.
+tool checks skip if ``ruff`` / ``pyright`` are not installed.
 """
 
 from __future__ import annotations
 
+import os
 import re
 import shutil
 import subprocess
@@ -68,13 +69,14 @@ def _tool(name: str) -> str | None:
 
 ROOT = _repo_root()
 _RUFF = _tool("ruff")
-_PYREFLY = _tool("pyrefly")
+_PYRIGHT = _tool("pyright")
 
 pytestmark = pytest.mark.skipif(
     ROOT is None, reason="docs sources not on disk (installed wheel) -- source-tree check only"
 )
 
 _FENCE = re.compile(r"^```python\s*$(.*?)^```", re.MULTILINE | re.DOTALL)
+_PYRIGHT_PREFIX = "# pyright: reportUnusedExpression=false\n"
 # directories that never hold published docs: build output, deps, caches, VCS, and the
 # repo's `temp/` scratch area
 _SKIP_DIRS = {
@@ -89,10 +91,15 @@ _SKIP_DIRS = {
     ".mypy_cache",
     "temp",
 }
+_SKIP_FILES = {"REVIEW.md"}
 
 
 def _doc_files(root: Path) -> list[Path]:
-    return sorted(p for p in root.rglob("*.md") if not _SKIP_DIRS.intersection(p.relative_to(root).parts))
+    return sorted(
+        p
+        for p in root.rglob("*.md")
+        if p.name not in _SKIP_FILES and not _SKIP_DIRS.intersection(p.relative_to(root).parts)
+    )
 
 
 def _blocks() -> list[tuple[str, str]]:
@@ -134,33 +141,36 @@ def test_doc_block_lints(code: str, tmp_path: Path) -> None:
     assert proc.returncode == 0, f"ruff check failed:\n{proc.stdout}{proc.stderr}"
 
 
-@pytest.mark.skipif(_PYREFLY is None, reason="pyrefly not installed")
+@pytest.mark.skipif(_PYRIGHT is None, reason="pyright not installed")
 @pytest.mark.parametrize("code", _CODES, ids=_IDS)
 def test_doc_block_typechecks(code: str, tmp_path: Path) -> None:
-    assert _PYREFLY is not None  # narrowed by the skipif above
+    assert _PYRIGHT is not None  # narrowed by the skipif above
     assert ROOT is not None  # narrowed by the module-level skipif
     block = tmp_path / "block.py"
-    block.write_text(code)
-    # --config is required: without it, pyrefly silently checks NOTHING for a file
-    # outside any configured project (it reports "0 errors" without analyzing), so
-    # the block must be checked against the repo config explicitly
+    block.write_text(_PYRIGHT_PREFIX + code)
     proc = subprocess.run(
-        [_PYREFLY, "check", "--config", str(ROOT / "pyproject.toml"), str(block)],
+        [_PYRIGHT, "--project", str(ROOT / "pyproject.toml"), str(block)],
         capture_output=True,
         text=True,
         cwd=ROOT,  # resolve `encomp` via the project venv
     )
-    assert proc.returncode == 0, f"pyrefly check failed:\n{proc.stdout}{proc.stderr}"
+    assert proc.returncode == 0, f"pyright failed:\n{proc.stdout}{proc.stderr}"
 
 
 @pytest.mark.parametrize("code", _CODES, ids=_IDS)
 def test_doc_block_runs(code: str, tmp_path: Path) -> None:
+    assert ROOT is not None  # narrowed by the module-level skipif
     block = tmp_path / "block.py"
     block.write_text(code)
+    env = {
+        **dict(os.environ),
+        "PYTHONPATH": f"{ROOT}{os.pathsep}{os.environ.get('PYTHONPATH', '')}".rstrip(os.pathsep),
+    }
     proc = subprocess.run(
         [sys.executable, str(block)],
         capture_output=True,
         text=True,
         cwd=tmp_path,  # scratch files a block creates (e.g. the .env example) land in tmp
+        env=env,
     )
     assert proc.returncode == 0, f"doc block failed:\n--- stdout:\n{proc.stdout}\n--- stderr:\n{proc.stderr}"

--- a/encomp/tests/test_examples.py
+++ b/encomp/tests/test_examples.py
@@ -169,7 +169,7 @@ class TestREADMEExamples:
 
 
 class TestUsageExamples:
-    """Test examples from docs/usage.rst"""
+    """Test examples from docs/usage.md"""
 
     def test_quantity_types(self) -> None:
         """Test quantity types and dimensionalities"""

--- a/encomp/tests/test_examples.py
+++ b/encomp/tests/test_examples.py
@@ -1,4 +1,4 @@
-from typing import Any, cast
+from typing import Any, assert_type, cast
 
 import numpy as np
 import pytest
@@ -21,6 +21,16 @@ from ..utypes import (
 
 # pytest.approx is loosely typed; expose it as an Any-typed alias
 approx = cast(Any, pytest).approx
+
+
+def _assert_type(val: object, typ: type) -> None:
+    from encomp.misc import isinstance_types
+
+    if not isinstance_types(val, typ):
+        raise TypeError(f"Type mismatch for {val}: {type(val)}, expected {typ}")
+
+
+assert_type.__code__ = _assert_type.__code__
 
 
 class TestREADMEExamples:
@@ -50,10 +60,10 @@ class TestREADMEExamples:
         """Test the Quantity type system with dimensionalities"""
         # the unit "kg" is registered as a Mass unit
         m = Q(12, "kg")
-        assert isinstance_types(m, Q[Mass])
+        assert_type(m, Q[Mass, float])
 
         V = Q(25, "liter")
-        assert isinstance_types(V, Q[Volume])
+        assert_type(V, Q[Volume, float])
 
         # common / and * operations
         _ = m / V
@@ -62,7 +72,8 @@ class TestREADMEExamples:
         # the unit "kg/week" is not registered by default
         m_ = Q(25, "kg/week")
 
-        # at runtime, the dimensionality of m_ will be evaluated to MassFlow
+        # "kg/week" is intentionally not in the literal overloads; only the runtime
+        # dimensionality resolver can prove this is MassFlow.
         assert isinstance_types(m_, Q[MassFlow])
 
         # these operations (Mass**2 divided by Volume) are not explicitly defined
@@ -71,7 +82,7 @@ class TestREADMEExamples:
         # the unit name "meter cubed" is not defined using an overload,
         # the type parameter Volume is used to infer the type
         y = Q(15, "meter cubed").asdim(Volume)
-        assert isinstance_types(y, Q[Volume])
+        assert_type(y, Q[Volume, float])
 
     def test_runtime_type_checking(self) -> None:
         """Test runtime type checking with typeguard"""
@@ -83,8 +94,8 @@ class TestREADMEExamples:
 
         # the dimensionalities check out
         result = some_func(Q(12, "delta_degC"))
-        assert isinstance_types(result[0], Q[Length])
-        assert isinstance_types(result[1], Q[Pressure])
+        assert_type(result[0], Q[Length, float])
+        assert_type(result[1], Q[Pressure, float])
 
         # raises an exception with wrong dimensionality
         with pytest.raises(TypeCheckError, match="is not an instance"):
@@ -99,7 +110,7 @@ class TestREADMEExamples:
 
         # note the extra parentheses around (kg/s)
         qty = Q(1, "delta_degC/(kg/s)").asdim(TemperaturePerMassFlowTest)
-        assert isinstance_types(qty, Q[TemperaturePerMassFlowTest])
+        assert_type(qty, Q[TemperaturePerMassFlowTest, float])
 
         with pytest.raises(ExpectedDimensionalityError):
             _ = Q(1, "delta_degC/(liter/hour)").asdim(TemperaturePerMassFlowTest)
@@ -111,7 +122,9 @@ class TestREADMEExamples:
         q2 = Q(3, "delta_degF per (pound per fortnight)")
 
         assert q1 == q2
-        # Both are instances of the same dimensionality
+        # CustomCoolingCapacity is an alias returned by the runtime metaclass, and
+        # q2 uses prose unit spelling outside the literal overloads; the checker
+        # cannot prove either custom dimensionality here.
         assert isinstance_types(q1, Q[TemperaturePerMassFlowTest])
         assert isinstance_types(q2, Q[TemperaturePerMassFlowTest])
 
@@ -161,10 +174,10 @@ class TestUsageExamples:
     def test_quantity_types(self) -> None:
         """Test quantity types and dimensionalities"""
         pressure = Q(1, "bar")
-        assert isinstance_types(pressure, Q[Pressure])
+        assert_type(pressure, Q[Pressure, float])
 
         fraction = Q(5, "%")
-        assert isinstance_types(fraction, Q[Dimensionless])
+        assert_type(fraction, Q[Dimensionless, float])
 
         pressure_kPa = pressure.to("kPa")
         assert type(pressure) is type(pressure_kPa)
@@ -179,7 +192,7 @@ class TestUsageExamples:
             dimensions = Power.dimensions / Length.dimensions
 
         qty = Q(100, "W/m").asdim(PowerPerLengthTest)
-        assert isinstance_types(qty, Q[PowerPerLengthTest])
+        assert_type(qty, Q[PowerPerLengthTest, float])
 
     def test_isinstance_checks(self) -> None:
         """Test isinstance and check methods"""
@@ -190,7 +203,8 @@ class TestUsageExamples:
         assert not pressure.check(Length)
         assert not pressure.check("meter")
 
-        # alternative using isinstance()
+        # This block demonstrates the runtime checking API from the docs; it is
+        # intentionally not replaced by assert_type.
         assert isinstance_types(pressure, Q[Pressure])
         assert not isinstance_types(pressure, Q[Length])
 
@@ -258,6 +272,8 @@ class TestUsageExamples:
         price = Q(25, "EUR/ton")
 
         yearly_cost = mf * t * price
+        # Currency is a custom unit combined through arithmetic; this is resolved
+        # from runtime unit dimensions rather than a static overload.
         assert isinstance_types(yearly_cost, Q[Currency])
 
         # SI prefixes can be used
@@ -286,9 +302,9 @@ class TestUsageExamples:
 
         # Valid model creation
         model = Model(a=Q(25, "cSt"), m=Q(25, "kg"), s=Q(25, "cm"))
-        assert isinstance_types(model.a, Q)
-        assert isinstance_types(model.m, Q[Mass])
-        assert isinstance_types(model.s, Q[Length])
+        assert_type(model.a, Q[Any, Any])
+        assert_type(model.m, Q[Mass, float])
+        assert_type(model.s, Q[Length, float])
 
         # Invalid dimensionality raises a Pydantic validation error
         with pytest.raises(ValidationError):

--- a/encomp/tests/test_fluids.py
+++ b/encomp/tests/test_fluids.py
@@ -89,6 +89,15 @@ def test_Fluid() -> None:
         # cannot fix all of P, T, Q
         Water(P=Q(1, "bar"), T=Q(150, "degC"), Q=Q(0.4, ""))
 
+    with pytest.raises(ValueError, match="same state input"):
+        Fluid("water", D=Q(1, "kg/m³"), Dmass=Q(1, "kg/m³"))
+
+    with pytest.raises(ValueError, match="same state input"):
+        HumidAir(T=Q(25, "degC"), Tdb=Q(25, "degC"), P=Q(1, "bar"))
+
+    with pytest.raises(ValueError, match="same state input"):
+        HumidAir(T=Q(25, "degC"), W=Q(0.01, ""), HumRat=Q(0.01, ""))
+
     with pytest.raises(ValueError):
         # incorrect argument name (built dynamically so the static
         # Unpack[TypedDict] key check does not flag the intentional typo)

--- a/encomp/tests/test_gases.py
+++ b/encomp/tests/test_gases.py
@@ -12,7 +12,6 @@ from ..gases import (
     mass_to_normal_volume,
     normal_volume_to_actual_volume,
 )
-from ..misc import isinstance_types
 from ..units import Quantity as Q
 from ..utypes import (
     Density,
@@ -88,9 +87,11 @@ def test_gas_conversion() -> None:
     P = Q(1, "atm")
     T = Q(25, "degC")
 
-    assert isinstance_types(mass_from_actual_volume(V, (P, T)), Q[Mass])
+    assert_type(mass_from_actual_volume(V, (P, T)), Q[Mass, float])
+    assert_type(mass_from_actual_volume(V, "N"), Q[Mass, float])
 
-    assert isinstance_types(mass_to_actual_volume(m, (P, T)), Q[Volume])
+    assert_type(mass_to_actual_volume(m, (P, T)), Q[Volume, float])
+    assert_type(mass_to_actual_volume(m, "S"), Q[Volume, float])
 
     # the normal-volume side carries the NormalVolume dimensionality (Nm³)
     # (assert_type also verifies the runtime type via the monkeypatch above; a
@@ -98,9 +99,11 @@ def test_gas_conversion() -> None:
     nv = actual_volume_to_normal_volume(V, (P, T))
     assert_type(nv, Q[NormalVolume, Any])
     assert nv.check(Q(0, "Nm³"))
+    assert_type(actual_volume_to_normal_volume(V, "N"), Q[NormalVolume, Any])
 
     v_actual = normal_volume_to_actual_volume(nv, (P, T))
     assert_type(v_actual, Q[Volume, Any])
+    assert_type(normal_volume_to_actual_volume(nv, "S"), Q[Volume, Any])
 
     # round trip recovers the original value
     assert v_actual.to("liter").m == approx(V.m, rel=1e-9)

--- a/encomp/tests/test_misc.py
+++ b/encomp/tests/test_misc.py
@@ -3,7 +3,16 @@ from typing import Any, cast
 
 from ..misc import isinstance_types, name_assignments
 from ..units import Quantity as Q
-from ..utypes import Dimensionless, Mass, Power, Temperature, UnknownDimensionality
+from ..utypes import (
+    Dimensionless,
+    Mass,
+    Power,
+    Temperature,
+    UnknownDimensionality,
+)
+
+# This module tests the runtime isinstance_types helper itself, so it keeps
+# direct isinstance_types assertions instead of replacing them with assert_type.
 
 
 def test_name_assignments() -> None:

--- a/encomp/tests/test_overloads.py
+++ b/encomp/tests/test_overloads.py
@@ -65,6 +65,10 @@ def test_eq() -> None:
 
     assert pl.DataFrame({"mass_kg": [1, 2, 3]}).select(expr).sum().item() == 1
 
+    tolerant_expr = Q(pl.col("x"), "m") == Q(0.3, "m")
+    assert_type(tolerant_expr, pl.Expr)
+    assert pl.DataFrame({"x": [0.1 + 0.2]}).select(tolerant_expr).item() is True
+
 
 def test_unknown_mul_div() -> None:
     q1 = Q(2, "kilogram")

--- a/encomp/tests/test_units.py
+++ b/encomp/tests/test_units.py
@@ -103,7 +103,8 @@ def test_registry() -> None:
     assert len(set(map(id, us))) == 1
 
     # check that units from all objects can be combined
-    # NOTE: there is not typing for quantities created by this method
+    # NOTE: there is not typing for quantities created by this method, so this
+    # has to stay a runtime-only type assertion.
     q = 1 * cast(Any, UNIT_REGISTRY).kg / _DEFAULT_REGISTRY.s**2 / cast(Any, application_registry.get()).m
     assert isinstance_types(q, Q[Pressure, Any])
 
@@ -123,6 +124,12 @@ def test_define_dimensionality() -> None:
 
     with pytest.raises(ValueError, match="if_exists"):
         define_dimensionality(CUSTOM_DIMENSIONS[0], if_exists=cast(Any, "invalid"))
+
+    with pytest.raises(ValueError, match="if_exists"):
+        define_dimensionality("fresh_invalid_if_exists", if_exists=cast(Any, "invalid"))
+
+    with pytest.raises(DimensionalityRedefinitionError):
+        define_dimensionality("meter")
 
 
 def test_format() -> None:
@@ -284,13 +291,16 @@ def test_function_annotations() -> None:
 
     a = return_input(cast(Any, Q(25, "m")))
 
+    # The generic function is intentionally called through Any; the checker cannot
+    # prove the returned dimensionality, but runtime dispatch must.
     assert isinstance_types(a, Q[Length])
 
     # not possible to determine output dimensionality for this
     def divide_by_time(q: Q[DT, MT]) -> Q[Any, MT]:
         return q / Q(1, "h")
 
-    # this will be resolved to MassFlow at runtime
+    # The generic return type erases dimensionality; this will be resolved to
+    # MassFlow only at runtime.
     assert isinstance_types(divide_by_time(cast(Any, Q(25, "kg"))), Q[MassFlow])
 
 
@@ -331,6 +341,9 @@ def test_dimensionality_type_hierarchy() -> None:
 
         # the dimensionality type is preserved for add, sub and
         # mul, div with scalars and Q[Dimensionless]
+        # These use local dimensionality subclasses and runtime subclass
+        # compatibility; the static checker cannot express all of these
+        # metaclass-created relationships across the arithmetic operations.
 
         assert isinstance_types(s, Q[EstimatedLength])
         assert isinstance_types(s.to_root_units(), Q[EstimatedLength])
@@ -416,6 +429,8 @@ def test_type_eq() -> None:
     q_arr = Q([25], "m")
 
     assert isinstance(q, Q)
+    # This test is about isinstance_types narrowing behavior, so these are
+    # intentionally runtime checks rather than assert_type-only assertions.
     assert isinstance_types(q, Q[Length, float])
     assert isinstance_types(q, Q[Length, Any])
 
@@ -544,9 +559,26 @@ def test_magnitude_setter() -> None:
     qa = Q(np.array([1.0, 2.0]), "m")
     qa.m = cast(Any, [3.0, 4.0])  # list -> ndarray via constructor validation
     assert isinstance(qa.m, np.ndarray)
+    qa_m = cast("Numpy1DArray", cast(Any, qa).m)
+    assert qa_m.dtype == np.float64
+
+    qa.m = cast(Any, np.array([1, 2]))
+    qa_m = cast("Numpy1DArray", cast(Any, qa).m)
+    assert qa_m.dtype == np.float64
 
     with pytest.raises(TypeError, match="astype"):
         qa.m = cast(Any, 1.0)
+
+    with pytest.raises(ValueError, match="strings"):
+        q.m = cast(Any, "24")
+
+
+def test_subscripted_constructor_rejects_invalid_magnitudes() -> None:
+    invalid: list[Any] = ["24", None, [[1.0, 2.0], [3.0, 4.0]], ["1", "2"]]
+
+    for value in invalid:
+        with pytest.raises(ValueError):
+            Q[Mass](value, "kg")
 
 
 def test_Q() -> None:
@@ -561,14 +593,7 @@ def test_Q() -> None:
     Q(1, "cSt")
     Q([])
 
-    units = [
-        "Δ%",
-        "ΔK",
-        "ΔdegC",
-        "Δ℃",
-        "℃",
-        "Δ°C",
-    ]
+    units = ["Δ%", "ΔK", "ΔdegC", "Δ℃", "℃", "Δ°C"]
 
     for unit in units:
         Q(1, unit)
@@ -605,9 +630,7 @@ def test_Q() -> None:
     assert Q(12).check("")
     assert Q(1) == Q(100, "%")
     Q[Dimensionless, float](21)
-    assert isinstance_types(Q(21), Q[Dimensionless])
-    assert isinstance_types(Q(21), Q[Dimensionless, float])
-    assert isinstance_types(Q(21), Q[Dimensionless, Any])
+    assert_type(Q(21), Q[Dimensionless, float])
     assert Q(1) == Q(1.0)
 
     assert isinstance(Q(1, "meter").m, float)
@@ -671,6 +694,7 @@ def test_Q() -> None:
 
     # floating point math might make this off at the N:th decimal
     assert P2.m == approx(2, rel=1e-12)
+    # "feet_water" is a runtime Pint unit alias, not a literal overload.
     assert isinstance_types(P2, Q[Pressure])
     assert_type(Q(Q(2, "feet_water"), Q(2, "kPa").u), Q[Pressure, float])
     assert_type(
@@ -694,7 +718,12 @@ def test_Q() -> None:
     # percent or %
     Q(1.124124e-3, "").to("%").to("percent")
     Q(1.124124e-3).to("%").to("percent")
-    assert Q(1.0, "mol%").u == Q(1.0, "mol percent").u
+    for unit in ("mol%", "mol-%", "mole%", "kg%", "m3%", "m³%", "vol%", "wt%"):
+        q_percent = Q(50.0, unit)
+        # The loop variable is a runtime str union, so the checker cannot select
+        # each literal unit overload; this pins the parser semantics at runtime.
+        assert q_percent.check(Dimensionless)
+        assert q_percent == Q(50.0, "%")
 
     # np.ndarray magnitudes equality check
     assert (Q([1, 2, 3], "kg") == Q([1000, 2000, 3000], "g")).all()
@@ -784,14 +813,19 @@ def test_wraps() -> None:
         # this is incorrect, cannot add 1 to a dimensional Quantity
         return a * b**2 + 1
 
+    # UNIT_REGISTRY.wraps is typed as Any here; only runtime dimensionality can
+    # validate the wrapped result.
     assert isinstance_types(func(Q(1, "yd"), Q(20, "lbs")), Q[Mass])
     assert Q(1, "bar").check(Pressure)
 
 
 def test_numpy_integration() -> None:
-    assert isinstance_types(Q(np.linspace(0, 1), "kg"), Q[Mass])
+    assert_type(Q(np.linspace(0, 1), "kg"), Q[Mass, Numpy1DArray])
+    # np.linspace is not typed to preserve Quantity subclasses; the integration is
+    # implemented by runtime numpy hooks.
     assert isinstance_types(np.linspace(Q(0, "kg"), Q(1, "kg")), Q[Mass])
 
+    # Same numpy hook limitation as above.
     assert isinstance_types(np.linspace(Q(2), Q(25, "%")), Q[Dimensionless])
     assert isinstance_types(np.linspace(Q(2, "cm"), Q(25, "km")), Q[Length])
 
@@ -802,6 +836,7 @@ def test_numpy_integration() -> None:
     comp = q1 == q2
     assert comp.all()
 
+    # Iterating a Quantity is runtime behavior; the checker sees a broad iterator.
     assert isinstance_types(list(Q(np.linspace(0, 1), "degC")), list[Q[Temperature]])
 
 
@@ -896,6 +931,7 @@ def test_generic_dimensionality() -> None:
     assert Q[Pressure] is not Q[Temperature]
     assert Q[Pressure] != Q[Temperature]
 
+    # These assertions exercise isinstance_types support for generic class objects.
     assert isinstance_types([Q, Q[Pressure], Q[Temperature]], list[type[Q]])
 
     assert not isinstance_types([Q, Q[Pressure], Q[Temperature]], list[Q])
@@ -942,6 +978,7 @@ def test_dynamic_dimensionalities() -> None:
     assert isinstance(q1, type(q2))
     assert isinstance(q2, type(q1))
     assert isinstance(q2, Q)
+    # Dynamic dimensionality classes are created from unit algebra at runtime.
     assert not isinstance_types(q2, Q[Pressure])
 
     q3 = Q(25, "m*g*g/(K^2*K^2)")
@@ -951,6 +988,8 @@ def test_dynamic_dimensionalities() -> None:
 
 
 def test_instance_checks() -> None:
+    # This test intentionally exercises the runtime isinstance_types API rather
+    # than static inference.
     assert isinstance_types(Q(2), Q[Dimensionless])
     assert isinstance(Q(2), Q)
 
@@ -1010,6 +1049,8 @@ def test_instance_checks() -> None:
 
 
 def test_typed_dict() -> None:
+    # TypedDict is not a runtime class; these are runtime-helper tests, not
+    # static assert_type candidates.
     d = {
         "P": Q[Pressure, float](25, "bar"),
         "T": Q[Temperature, float](25, "degC"),
@@ -1229,11 +1270,11 @@ def test_literal_units() -> None:
 def test_indexing() -> None:
     qs = Q([1, 2, 3], "kg")
 
-    assert isinstance_types(qs, Q[Mass])
+    assert_type(qs, Q[Mass, Numpy1DArray])
 
     qi = qs[1]
 
-    assert isinstance_types(qi, Q[Mass])
+    assert_type(qi, Q[Mass, float])
     assert qi == Q(2, "kg")
 
 
@@ -1274,6 +1315,8 @@ def test_unit_compatibility() -> None:
     # the UNIT_REGISTRY registry object contains unit attributes
     # that can be multiplied and divided by a magnitude
     # to create Quantity instances
+    # The registry attributes are cast from Any; this path validates runtime
+    # construction from Pint's dynamic unit objects.
 
     assert isinstance_types(cast(Any, UNIT_REGISTRY).m * 1, Q[Length])
     assert isinstance_types(1 * cast(Any, UNIT_REGISTRY).m / cast(Any, UNIT_REGISTRY).s, Q[Velocity])
@@ -1284,6 +1327,8 @@ def test_unit_compatibility() -> None:
 
 
 def test_mul_rmul_initialization() -> None:
+    # These exercise Pint/numpy operator dispatch paths that are exposed through
+    # Any or numpy protocols rather than overloads.
     assert isinstance_types(cast(Any, UNIT_REGISTRY).m * np.array([1, 2]), Q[Length])
     # this returns array([<Quantity(1.0, 'meter')>, <Quantity(2.0, 'meter')>], dtype=object) instead
     # assert isinstance_types(np.array([1, 2]) * cast(Any, UNIT_REGISTRY).m, Q[Length])
@@ -1295,7 +1340,9 @@ def test_mul_rmul_initialization() -> None:
 def test_copy() -> None:
     q = Q(25, "m")
 
-    assert isinstance_types(q, Q[Length])
+    assert_type(q, Q[Length, float])
+    # Copy/deepcopy preserve the runtime subclass; their return paths are not
+    # modeled precisely enough for assert_type here.
     assert isinstance_types(q.__copy__(), Q[Length])
 
     assert isinstance_types(q.__deepcopy__(), Q[Length])
@@ -1309,6 +1356,7 @@ def test_pickle_preserves_dimensionality_type() -> None:
     dt = Q(5.0, "delta_degC").to("K")
     dt_roundtrip = pickle.loads(pickle.dumps(dt))
 
+    # pickle.loads returns Any, so dimensionality preservation is runtime-only.
     assert isinstance_types(dt_roundtrip, Q[TemperatureDifference])
     assert dt_roundtrip.u == Unit("K")
     assert dt_roundtrip == dt
@@ -1319,6 +1367,11 @@ def test_pickle_preserves_dimensionality_type() -> None:
     assert isinstance_types(hv_roundtrip, Q[HeatingValue])
     assert hv_roundtrip.u == Unit("kilojoule / kilogram")
     assert hv_roundtrip == hv
+
+    derived = Q(1.0, "m") * Q(1.0, "K")
+    derived_roundtrip = pickle.loads(pickle.dumps(derived))
+    assert derived_roundtrip.u == Unit("meter * kelvin")
+    assert derived_roundtrip == derived
 
 
 def test_pydantic_integration() -> None:
@@ -1360,11 +1413,11 @@ def test_temperature_difference() -> None:
         _ = Q(25, "K").to("delta_degC")
 
     T0 = Q(25, "K").asdim(TemperatureDifference).to("delta_degC")
-    assert isinstance_types(T0, Q[TemperatureDifference])
+    assert_type(T0, Q[TemperatureDifference, float])
     assert T0.m == approx(25.0)
 
     td_offset = Q(20, "degC").asdim(TemperatureDifference)
-    assert isinstance_types(td_offset, Q[TemperatureDifference])
+    assert_type(td_offset, Q[TemperatureDifference, float])
     assert td_offset.u == Unit("delta_degC")
     assert td_offset.to("K").m == approx(20.0)
     assert (Q(30, "degC") + td_offset).m == approx(50.0)
@@ -1372,19 +1425,29 @@ def test_temperature_difference() -> None:
     with pytest.raises(DimensionalityTypeError, match="delta unit"):
         Q[TemperatureDifference, float](5, "degC")
 
+    class CustomTemperatureDifference(TemperatureDifference):
+        dimensions = TemperatureDifference.dimensions
+
+    with pytest.raises(DimensionalityTypeError, match="delta unit"):
+        Q[CustomTemperatureDifference, float](5, "degC")
+
     T1 = Q(25, "degC")
     T2 = Q(35, "degC")
 
     dT1 = T1 - T2
     dT2 = T2 - T1
 
-    assert isinstance_types(dT1, Q[TemperatureDifference])
-    assert isinstance_types(dT2, Q[TemperatureDifference])
+    assert_type(dT1, Q[TemperatureDifference, float])
+    assert_type(dT2, Q[TemperatureDifference, float])
 
     assert dT1.u == Unit("delta_degC")
     assert dT2.u == Unit("delta_degC")
 
     assert (Q(25, "degF") - Q(30, "degF")).u == Unit("delta_degF")
+    assert_type(Q(1, "ΔK"), Q[TemperatureDifference, float])
+    assert Q(1, "ΔK").u == Unit("delta_K")
+    assert Q(1, "K").check(Temperature)
+    assert Q(1, "degRe").asdim(TemperatureDifference).u == Unit("delta_degRe")
 
     with pytest.raises(OffsetUnitCalculusError):
         _ = T1 + T2
@@ -1398,14 +1461,14 @@ def test_temperature_difference() -> None:
     with pytest.raises(OffsetUnitCalculusError):
         _ = T1 / 2
 
-    assert isinstance_types(dT1, Q[TemperatureDifference])
-    assert isinstance_types(dT1.to("delta_degF"), Q[TemperatureDifference])
+    assert_type(dT1, Q[TemperatureDifference, float])
+    assert_type(dT1.to("delta_degF"), Q[TemperatureDifference, float])
 
-    assert isinstance_types(dT2, Q[TemperatureDifference])
-    assert isinstance_types(dT2 + dT1, Q[TemperatureDifference])
+    assert_type(dT2, Q[TemperatureDifference, float])
+    assert_type(dT2 + dT1, Q[TemperatureDifference, float])
 
-    assert isinstance_types(T1 + dT1, Q[Temperature])
-    assert isinstance_types(dT1 + T1, Q[Temperature])
+    assert_type(T1 + dT1, Q[Temperature, float])
+    assert_type(dT1 + T1, Q[Temperature, float])
 
     with pytest.raises(DimensionalityTypeError):
         (T1 - T2).to("degC")
@@ -1414,11 +1477,11 @@ def test_temperature_difference() -> None:
     # and keeps the TemperatureDifference dimensionality; only offset scales
     # (degC, degF) are refused
     dk = (T1.to("K") - T2.to("K")).to("K")
-    assert isinstance_types(dk, Q[TemperatureDifference])
+    assert_type(dk, Q[TemperatureDifference, float])
     assert dk.m == approx(-10.0)
 
     dk2 = (T1 - T2).to("K")
-    assert isinstance_types(dk2, Q[TemperatureDifference])
+    assert_type(dk2, Q[TemperatureDifference, float])
     assert dk2.m == approx(-10.0)
 
     with pytest.raises(DimensionalityTypeError):
@@ -1428,12 +1491,12 @@ def test_temperature_difference() -> None:
     T2 = T1.to("K") - Q(100, "degC").to("K")
 
     dk3 = T2.to("K")
-    assert isinstance_types(dk3, Q[TemperatureDifference])
+    assert_type(dk3, Q[TemperatureDifference, float])
     assert dk3.m == approx(700.0)
 
     T2_ = T1.to("K") - Q(100, "delta_degC")
 
-    assert isinstance_types(T2_, Q[Temperature])
+    assert_type(T2_, Q[Temperature, float])
 
 
 def test_ordering_comparisons_across_dimensionalities() -> None:
@@ -1478,7 +1541,7 @@ def test_to_preserves_temperature_dimensionality() -> None:
 
     # .asdim() is the explicit, value-preserving escape hatch
     td = Q(300.0, "K").asdim(TemperatureDifference)
-    assert isinstance_types(td, Q[TemperatureDifference])
+    assert_type(td, Q[TemperatureDifference, float])
     assert td.to("delta_degC").m == approx(300.0)
     assert td.to("delta_degF").m == approx(540.0)
 
@@ -1499,6 +1562,8 @@ def test_inplace_add_sub_checks_dimensionality() -> None:
 
     td = Q(np.array([10.0]), "delta_degC")
     td += Q(np.array([20.0]), "degC")
+    # Augmented assignment changes dimensionality at runtime; the checker keeps
+    # the original variable type, so this specific assertion must be runtime-only.
     assert isinstance_types(td, Q[Temperature])
     assert td.u == Unit("degC")
     assert td.m == approx(np.array([30.0]))
@@ -1514,7 +1579,7 @@ def test_temperature_add_sub_preserves_unit() -> None:
     res = Q(300.0, "K") + Q(10.0, "delta_degC")
     assert res.u == Unit("K")
     assert res.m == approx(310.0)
-    assert isinstance_types(res, Q[Temperature])
+    assert_type(res, Q[Temperature, float])
 
     res = Q(10.0, "delta_degC") + Q(300.0, "K")
     assert res.u == Unit("K")
@@ -1571,7 +1636,7 @@ def test_temperature_difference_to_multiplicative_units() -> None:
     dt = Q(10.0, "delta_degC")
 
     k = dt.to("K")
-    assert isinstance_types(k, Q[TemperatureDifference])
+    assert_type(k, Q[TemperatureDifference, float])
     assert k.m == approx(10.0)
     assert k.u == Unit("K")
 
@@ -1583,13 +1648,15 @@ def test_temperature_difference_to_multiplicative_units() -> None:
 
     # to_base_units agrees with to_root_units (both express the ΔT in K)
     base = dt.to_base_units()
-    assert isinstance_types(base, Q[TemperatureDifference])
+    assert_type(base, Q[TemperatureDifference, float])
     assert base.m == approx(10.0)
     assert base.m == approx(dt.to_root_units().m)
 
     # in-place conversion keeps the dimensionality type too
     arr = Q(np.array([10.0, 20.0]), "delta_degC")
     arr.ito("K")
+    # In-place conversion preserves the runtime dimensionality, but pyrefly
+    # widens the value after .ito(), so this remains runtime-only.
     assert isinstance_types(arr, Q[TemperatureDifference])
     assert arr.m == approx(np.array([10.0, 20.0]))
 
@@ -1623,6 +1690,8 @@ def test_temperature_unit_inputs() -> None:
     ]:
         qty = Q(1, unit)
 
+        # The unit is a loop-time string, so the checker cannot select a single
+        # literal overload; this pins the runtime parser behavior.
         assert isinstance_types(qty, Q[Temperature]) or isinstance_types(qty, Q[TemperatureDifference])
         assert qty.check(Temperature)
         assert qty.check(TemperatureDifference)
@@ -1648,10 +1717,10 @@ def test_nested_quantity_input() -> None:
 
 def test_getitem() -> None:
     ms = Q([1.2, 1.3], "kg")
-    assert isinstance_types(ms, Q[Mass, np.ndarray])
+    assert_type(ms, Q[Mass, Numpy1DArray])
 
     m0 = ms[0]
-    assert isinstance_types(m0, Q[Mass, float])
+    assert_type(m0, Q[Mass, float])
 
 
 def test_class_getitem() -> None:
@@ -1900,20 +1969,20 @@ def test_unary_pos_neg() -> None:
     assert -Q(-1) == 1
 
     assert (-Q(25, "kg")).mt_name == "float"
-    assert isinstance_types(-Q(25, "kg"), Q[Mass, float])
-    assert isinstance_types(-1 * -Q(25, "kg"), Q[Mass, float])
-    assert isinstance_types(-Q(25, "kg") * 1, Q[Mass, float])
-    assert isinstance_types(-Q(25, "kg") * -1, Q[Mass, float])
-    assert isinstance_types(-(1 * -Q(25, "kg")), Q[Mass, float])
+    assert_type(-Q(25, "kg"), Q[Mass, float])
+    assert_type(-1 * -Q(25, "kg"), Q[Mass, float])
+    assert_type(-Q(25, "kg") * 1, Q[Mass, float])
+    assert_type(-Q(25, "kg") * -1, Q[Mass, float])
+    assert_type(-(1 * -Q(25, "kg")), Q[Mass, float])
 
     assert +Q(+1) == 1
 
     assert (+Q(25, "kg")).mt_name == "float"
-    assert isinstance_types(+Q(25, "kg"), Q[Mass, float])
-    assert isinstance_types(+1 * +Q(25, "kg"), Q[Mass, float])
-    assert isinstance_types(+Q(25, "kg") * 1, Q[Mass, float])
-    assert isinstance_types(+Q(25, "kg") * +1, Q[Mass, float])
-    assert isinstance_types(+(1 * +Q(25, "kg")), Q[Mass, float])
+    assert_type(+Q(25, "kg"), Q[Mass, float])
+    assert_type(+1 * +Q(25, "kg"), Q[Mass, float])
+    assert_type(+Q(25, "kg") * 1, Q[Mass, float])
+    assert_type(+Q(25, "kg") * +1, Q[Mass, float])
+    assert_type(+(1 * +Q(25, "kg")), Q[Mass, float])
 
 
 def test_dimensionless_division() -> None:
@@ -1924,26 +1993,51 @@ def test_dimensionless_division() -> None:
     assert_type(1 / Q(pl.col.test), Q[Dimensionless, pl.Expr])
 
 
+def test_in_place_operators_rebuild_subclass() -> None:
+    q_mul = Q(np.array([1.0, 2.0]), "kg")
+    q_mul *= Q(3.0, "m")
+    assert q_mul.u == Unit("kilogram * meter")
+    # Augmented assignment changes dimensionality at runtime; the checker keeps
+    # the original variable type, so this specific assertion must be runtime-only.
+    assert not isinstance_types(q_mul, Q[Mass])
+    assert (q_mul + Q(np.array([1.0, 1.0]), "kg*m") == Q(np.array([4.0, 7.0]), "kg*m")).all()
+
+    q_div = Q(np.array([2.0, 4.0]), "kg")
+    q_div /= Q(2.0, "s")
+    assert q_div.u == Unit("kilogram / second")
+    assert (q_div + Q(np.array([1.0, 1.0]), "kg/s") == Q(np.array([2.0, 3.0]), "kg/s")).all()
+
+    q_pow = Q(np.array([2.0, 3.0]), "m")
+    q_pow **= 2
+    # Same augmented-assignment limitation as above: runtime dimensionality changes.
+    assert isinstance_types(q_pow, Q[Area])
+    assert (q_pow == Q(np.array([4.0, 9.0]), "m²")).all()
+
+    q_floor = Q(np.array([5.0, 7.0]), "m")
+    q_floor //= Q(2.0, "m")
+    # Same augmented-assignment limitation as above: runtime dimensionality changes.
+    assert isinstance_types(q_floor, Q[Dimensionless])
+    assert (q_floor == Q(np.array([2.0, 3.0]))).all()
+
+
 def test_massflow_energypermass_power_mul() -> None:
     mf = Q(10, "kg/s")
     epm = Q(1000, "kJ/kg")
 
     result = mf * epm
-    assert isinstance_types(result, Q[Power])
+    assert_type(result, Q[Power, float])
     assert_type(mf * epm, Q[Power, float])
 
     # commutative
     result2 = epm * mf
-    assert isinstance_types(result2, Q[Power])
+    assert_type(result2, Q[Power, float])
     assert_type(epm * mf, Q[Power, float])
 
     # array magnitude types
     mf_arr = Q([10, 20], "kg/s")
-    assert isinstance_types(mf_arr * epm, Q[Power])
     assert_type(mf_arr * epm, Q[Power, Numpy1DArray])
 
     mf_series = Q(pl.Series([10, 20]), "kg/s")
-    assert isinstance_types(mf_series * epm, Q[Power])
     assert_type(mf_series * epm, Q[Power, pl.Series])
 
     mf_expr = Q(pl.col.test, "kg/s")
@@ -1951,7 +2045,6 @@ def test_massflow_energypermass_power_mul() -> None:
 
     # commutative with array types
     epm_arr = Q([1000, 2000], "kJ/kg")
-    assert isinstance_types(epm_arr * mf, Q[Power])
     assert_type(epm_arr * mf, Q[Power, Numpy1DArray])
 
 
@@ -1961,26 +2054,22 @@ def test_power_div_massflow_energypermass() -> None:
     epm = Q(1000, "kJ/kg")
 
     result1 = p / mf
-    assert isinstance_types(result1, Q[EnergyPerMass])
+    assert_type(result1, Q[EnergyPerMass, float])
     assert_type(p / mf, Q[EnergyPerMass, float])
 
     result2 = p / epm
-    assert isinstance_types(result2, Q[MassFlow])
+    assert_type(result2, Q[MassFlow, float])
     assert_type(p / epm, Q[MassFlow, float])
 
     # array magnitude types
     p_arr = Q([10000, 20000], "kW")
-    assert isinstance_types(p_arr / mf, Q[EnergyPerMass])
     assert_type(p_arr / mf, Q[EnergyPerMass, Numpy1DArray])
 
-    assert isinstance_types(p_arr / epm, Q[MassFlow])
     assert_type(p_arr / epm, Q[MassFlow, Numpy1DArray])
 
     p_series = Q(pl.Series([10000, 20000]), "kW")
-    assert isinstance_types(p_series / mf, Q[EnergyPerMass])
     assert_type(p_series / mf, Q[EnergyPerMass, pl.Series])
 
-    assert isinstance_types(p_series / epm, Q[MassFlow])
     assert_type(p_series / epm, Q[MassFlow, pl.Series])
 
     p_expr = Q(pl.col.test, "kW")

--- a/encomp/units.py
+++ b/encomp/units.py
@@ -15,6 +15,7 @@ import logging
 import math
 import numbers
 import re
+import sys
 import warnings
 from collections.abc import Iterable, Iterator, Sequence, Sized
 from types import UnionType
@@ -36,7 +37,7 @@ from typing import (
 import numpy as np
 import pint
 import polars as pl
-from pint.errors import DimensionalityError, UnitStrippedWarning
+from pint.errors import DimensionalityError, RedefinitionError, UnitStrippedWarning
 from pint.facets.measurement.objects import MeasurementQuantity
 from pint.facets.nonmultiplicative.objects import NonMultiplicativeQuantity
 from pint.facets.numpy.quantity import NumpyQuantity
@@ -299,6 +300,9 @@ def define_dimensionality(name: str, symbol: str | None = None, if_exists: Liter
         ``"warn"`` logs a warning and keeps the existing definition
     """
 
+    if if_exists not in ("raise", "warn"):
+        raise ValueError(f"Invalid value: {if_exists=}")
+
     if not name.isidentifier():
         raise ValueError(
             f"Dimensionality name must be a valid Python identifier (alphanumeric and underscores, "
@@ -309,20 +313,24 @@ def define_dimensionality(name: str, symbol: str | None = None, if_exists: Liter
         msg = f"Cannot define new dimensionality with name: {name}, a dimensionality with this name was already defined"
         if if_exists == "raise":
             raise DimensionalityRedefinitionError(msg)
-        elif if_exists == "warn":
-            # the existing definition stays in place: defining it again on the
-            # registry (on_redefinition="raise") would raise RedefinitionError
-            _LOGGER.warning(msg)
-            return
-        else:
-            raise ValueError(f"Invalid value: {if_exists=}")
+        # the existing definition stays in place: defining it again on the
+        # registry (on_redefinition="raise") would raise RedefinitionError
+        _LOGGER.warning(msg)
+        return
 
     definition_str = f"{name} = [{name}]"
 
     if symbol is not None:
         definition_str = f"{definition_str} = {symbol}"
 
-    UNIT_REGISTRY.define(definition_str)
+    try:
+        UNIT_REGISTRY.define(definition_str)
+    except RedefinitionError as e:
+        msg = f"Cannot define new dimensionality with name: {name}, a unit with this name was already defined"
+        if if_exists == "warn":
+            _LOGGER.warning(msg)
+            return
+        raise DimensionalityRedefinitionError(msg) from e
     CUSTOM_DIMENSIONS.append(name)
 
 
@@ -370,7 +378,12 @@ class Quantity(
 
     # constants
     NORMAL_M3_VARIANTS = ("nm³", "Nm³", "nm3", "Nm3", "nm**3", "Nm**3", "nm^3", "Nm^3")
-    TEMPERATURE_DIFFERENCE_UCS = (Unit("delta_degC")._units, Unit("delta_degF")._units)
+    TEMPERATURE_DIFFERENCE_UCS = (
+        Unit("delta_K")._units,
+        Unit("delta_degC")._units,
+        Unit("delta_degF")._units,
+        Unit("delta_degRe")._units,
+    )
 
     # used for float and numpy array comparison
     rtol: float = 1e-9
@@ -693,7 +706,13 @@ class Quantity(
             )
 
     @staticmethod
-    def _validate_magnitude(val: MT | Sequence[float]) -> MT:
+    def _validate_magnitude(val: MT | Sequence[float] | str | bytes | None) -> MT:
+        if val is None or isinstance(val, (str, bytes)):
+            raise ValueError(
+                "magnitude must be a numeric scalar, sympy atom, Polars object, "
+                "or 1-dimensional sequence of real numbers; strings and None are not supported"
+            )
+
         if isinstance(val, int):
             return cast("MT", float(val))
         elif isinstance(val, float):
@@ -704,7 +723,7 @@ class Quantity(
         elif isinstance(val, np.ndarray):
             if len(val.shape) != 1:
                 raise ValueError(f"Only 1-dimensional Numpy arrays can be used as magnitude, got shape {val.shape}")
-            return val
+            return cast("MT", Quantity._cast_array_float(val))
         elif isinstance(val, (pl.Series, pl.Expr)):
             return val
         elif hasattr(val, "is_Atom"):
@@ -719,8 +738,10 @@ class Quantity(
             # of falling through to np.array(), which fails on the 0-d shape
             return cast("MT", float(val))
         else:
-            arr = cast(MT, np.array(val).astype(np.float64))
-            return arr
+            arr = np.array(val)
+            if len(arr.shape) != 1:
+                raise ValueError(f"Only 1-dimensional sequences can be used as magnitude, got shape {arr.shape}")
+            return cast("MT", Quantity._cast_array_float(arr))
 
     @classmethod
     def get_unit(cls, unit_name: AllUnits | str) -> Unit:
@@ -764,17 +785,31 @@ class Quantity(
 
     def __reduce__(  # pyright: ignore[reportIncompatibleMethodOverride]  # pyrefly: ignore[bad-override]
         self,
-    ) -> tuple[object, tuple[object, str, type[Dimensionality]]]:
-        return (_reconstruct_quantity, (self._magnitude, str(self.u._units), self.dt))
+    ) -> tuple[object, tuple[object, str, type[Dimensionality] | None]]:
+        dim = self.dt if _is_pickle_global(self.dt) else None
+        return (_reconstruct_quantity, (self._magnitude, str(self.u._units), dim))
 
     @staticmethod
     def _cast_array_float(inp: np.ndarray) -> Numpy1DArray:
         # don't fail in case the array contains unsupported objects,
         # cast to float64, matches the Numpy1DArray type definition
+        if inp.dtype.kind in {"S", "U"}:
+            raise ValueError("magnitude sequences must contain real numbers, not strings")
+
+        if inp.dtype.kind == "O":
+            for item in inp:
+                if item is None or isinstance(item, (str, bytes)) or not isinstance(item, numbers.Real):
+                    raise ValueError(
+                        f"magnitude sequences must contain real numbers; got {type(item).__name__}: {item!r}"
+                    )
+
+        if inp.dtype == np.float64:
+            return cast("Numpy1DArray", inp)
+
         try:
             return inp.astype(np.float64, casting="unsafe", copy=True)
-        except TypeError:
-            return inp
+        except (TypeError, ValueError) as e:
+            raise ValueError("magnitude sequences must contain real numbers") from e
 
     @overload
     def __new__(cls, val: Sequence[float]) -> Quantity[Dimensionless, Numpy1DArray]: ...
@@ -998,7 +1033,7 @@ class Quantity(
         valid_magnitude = cls._validate_magnitude(val)
         valid_unit = cls._validate_unit(unit)
 
-        if cls._dimensionality_type == TemperatureDifference and cls._is_offset_temperature_unit(valid_unit):
+        if issubclass(cls._dimensionality_type, TemperatureDifference) and cls._is_offset_temperature_unit(valid_unit):
             raise DimensionalityTypeError(
                 f"Cannot construct TemperatureDifference with offset unit {valid_unit}; use a delta unit instead"
             )
@@ -1094,7 +1129,7 @@ class Quantity(
 
     @property
     def _is_temperature_difference(self) -> bool:
-        return self.dt == TemperatureDifference
+        return issubclass(self.dt, TemperatureDifference)
 
     @classmethod
     def _is_temperature_difference_unit(cls, unit: Unit[DT]) -> bool:
@@ -1113,11 +1148,17 @@ class Quantity(
 
     @classmethod
     def _as_temperature_difference_unit(cls, unit: Unit[Any]) -> Unit[TemperatureDifference]:
+        if unit._units == Unit("delta_K")._units:
+            return Unit("delta_K")
+
         if unit._units == Unit("degC")._units:
             return Unit("delta_degC")
 
         if unit._units == Unit("degF")._units:
             return Unit("delta_degF")
+
+        if unit._units == Unit("degRe")._units:
+            return Unit("delta_degRe")
 
         if cls._is_offset_temperature_unit(unit):
             raise DimensionalityTypeError(f"Cannot reinterpret offset temperature unit {unit} as TemperatureDifference")
@@ -1361,13 +1402,15 @@ class Quantity(
             "‰": "permille",
             "r/min": "rpm",
             # ΔK does not really make sense, it's not an offset scale
-            "ΔK": "K",
             "Δ": "delta_",
         }
 
         for old, new in replacements.items():
             if old in unit:
                 unit = unit.replace(old, new)
+
+        percent_basis = r"(?:mol(?:e)?|kg|g|m(?:3|³|\^3|\*\*3)|vol(?:ume)?|mass|wt|weight)"
+        unit = re.sub(rf"(?<![A-Za-z0-9_]){percent_basis}\s*-?\s*%", "%", unit, flags=re.IGNORECASE)
 
         unit = re.sub(r"(?<=[A-Za-z0-9_])%", " percent", unit)
         unit = unit.replace("%", "percent")
@@ -1881,7 +1924,10 @@ class Quantity(
     def __pow__(self, other: Quantity[Dimensionless, MT]) -> Quantity[UnknownDimensionality, MT]: ...
     def __pow__(self, other: Quantity[Dimensionless, Any] | float) -> Quantity[Any, Any]:
         ret = cast("Quantity[DT, MT]", self._pint_super.__pow__(other))
-        return ret
+        return self._call_subclass(ret.m, ret.u)
+
+    def __ipow__(self, other: Any) -> Any:  # noqa: ANN401
+        return cast("Quantity[Any, Any]", cast(Any, self).__pow__(other))
 
     @overload
     def __add__(self: Quantity[Dimensionless, MT], other: float) -> Quantity[Dimensionless, MT]: ...
@@ -2084,6 +2130,12 @@ class Quantity(
         if isinstance(other_m, pl.Series) and isinstance(m, (float, int)):
             return other_m.is_close(m, rel_tol=self.rtol, abs_tol=self.atol)
 
+        if isinstance(m, pl.Expr) and isinstance(other_m, (float, int, pl.Expr)):
+            return m.is_close(other_m, rel_tol=self.rtol, abs_tol=self.atol)
+
+        if isinstance(other_m, pl.Expr) and isinstance(m, (float, int)):
+            return other_m.is_close(m, rel_tol=self.rtol, abs_tol=self.atol)
+
         ret = m == other_m
 
         return ret
@@ -2160,6 +2212,12 @@ class Quantity(
             return m.is_close(other_m, rel_tol=self.rtol, abs_tol=self.atol).not_()
 
         if isinstance(other_m, pl.Series) and isinstance(m, (float, int)):
+            return other_m.is_close(m, rel_tol=self.rtol, abs_tol=self.atol).not_()
+
+        if isinstance(m, pl.Expr) and isinstance(other_m, (float, int, pl.Expr)):
+            return m.is_close(other_m, rel_tol=self.rtol, abs_tol=self.atol).not_()
+
+        if isinstance(other_m, pl.Expr) and isinstance(m, (float, int)):
             return other_m.is_close(m, rel_tol=self.rtol, abs_tol=self.atol).not_()
 
         ret = m != other_m
@@ -2622,6 +2680,9 @@ class Quantity(
 
         return self._call_subclass(ret.m, ret.u)
 
+    def __imul__(self, other: Any) -> Any:  # noqa: ANN401
+        return cast("Quantity[Any, Any]", cast(Any, self).__mul__(other))
+
     def __rmul__(self, other: float) -> Quantity[DT, MT]:
         ret = cast("Quantity[DT, MT]", self._pint_super.__rmul__(other))
         return self._call_subclass(ret.m, ret.u)
@@ -2962,6 +3023,9 @@ class Quantity(
 
         return self._call_subclass(ret.m, ret.u)
 
+    def __itruediv__(self, other: Any) -> Any:  # noqa: ANN401
+        return cast("Quantity[Any, Any]", cast(Any, self).__truediv__(other))
+
     @overload
     def __rtruediv__(self: Quantity[Dimensionless, MT], other: float) -> Quantity[Dimensionless, MT]: ...
 
@@ -3009,6 +3073,9 @@ class Quantity(
         ret = self._pint_super.__floordiv__(other)
 
         return self._call_subclass(ret.m, ret.u)
+
+    def __ifloordiv__(self, other: Any) -> Any:  # noqa: ANN401
+        return cast("Quantity[Any, Any]", cast(Any, self).__floordiv__(other))
 
     def __abs__(self) -> Quantity[DT, MT]:
         ret = cast("Quantity[DT, MT]", super().__abs__())
@@ -3064,8 +3131,16 @@ class Quantity(
         return cast("Quantity[Any, Any]", instance)
 
 
-def _reconstruct_quantity(magnitude: object, unit: str, dim: type[Dimensionality]) -> Quantity[Any, Any]:
-    return Quantity(cast(Any, magnitude), unit).asdim(dim)
+def _is_pickle_global(dim: type[Dimensionality]) -> bool:
+    module = sys.modules.get(dim.__module__)
+    return module is not None and getattr(module, dim.__name__, None) is dim
+
+
+def _reconstruct_quantity(magnitude: object, unit: str, dim: type[Dimensionality] | None) -> Quantity[Any, Any]:
+    qty = Quantity(cast(Any, magnitude), unit)
+    if dim is None:
+        return qty
+    return qty.asdim(dim)
 
 
 # register the Quantity and Unit implementations on the registry, so every object

--- a/encomp/units.py
+++ b/encomp/units.py
@@ -240,8 +240,8 @@ class _LazyRegistry(LazyRegistry[Any, Any]):
 
 UNIT_REGISTRY = cast(UnitRegistry[Any], _LazyRegistry())
 
-for k, v in _REGISTRY_STATIC_OPTIONS.items():
-    setattr(UNIT_REGISTRY, k, v)
+for _option_name, _option_value in _REGISTRY_STATIC_OPTIONS.items():
+    setattr(UNIT_REGISTRY, _option_name, _option_value)
 
 # make sure that UNIT_REGISTRY is the only registry that can be used
 setattr(pint, "_DEFAULT_REGISTRY", UNIT_REGISTRY)  # noqa: B010

--- a/encomp/units.py
+++ b/encomp/units.py
@@ -739,6 +739,11 @@ class Quantity(
             return cast("MT", float(val))
         else:
             arr = np.array(val)
+            if len(arr.shape) == 0:
+                raise TypeError(
+                    "magnitude must be a numeric scalar, sympy atom, Polars object, "
+                    f"or 1-dimensional sequence of real numbers; got {type(val).__name__}"
+                )
             if len(arr.shape) != 1:
                 raise ValueError(f"Only 1-dimensional sequences can be used as magnitude, got shape {arr.shape}")
             return cast("MT", Quantity._cast_array_float(arr))

--- a/encomp/utypes.py
+++ b/encomp/utypes.py
@@ -30,6 +30,24 @@ DimensionlessUnits = Literal[
     "%",
     "percent",
     "pct",
+    "mol%",
+    "mol-%",
+    "mole%",
+    "mole-%",
+    "kg%",
+    "kg-%",
+    "m3%",
+    "m3-%",
+    "m³%",
+    "m³-%",
+    "vol%",
+    "vol-%",
+    "volume%",
+    "volume-%",
+    "wt%",
+    "wt-%",
+    "weight%",
+    "weight-%",
     "-",
     "dimensionless",
 ]
@@ -169,6 +187,8 @@ TemperatureUnits = Literal[
 ]
 
 TemperatureDifferenceUnits = Literal[
+    "delta_K",
+    "ΔK",
     "delta_°C",
     "delta_degC",
     "Δ°C",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "encomp"
-version = "1.6.0"
+version = "1.6.1"
 description = "General-purpose library for engineering calculations"
 authors = [{ name = "William Laurén", email = "lauren.william.a@gmail.com" }]
 requires-python = ">=3.13"
@@ -59,7 +59,7 @@ dependencies = [
 [dependency-groups]
 dev = [
     "pre-commit",
-    "maturin>=1.5,<2",
+    "maturin>=1.8.2,<2",
     "ruff",
     "pytest",
     "hypothesis",
@@ -92,7 +92,7 @@ Repository = "https://github.com/wlaur/encomp"
 Issues = "https://github.com/wlaur/encomp/issues"
 
 [build-system]
-requires = ["maturin>=1.5,<2"]
+requires = ["maturin>=1.8.2,<2"]
 build-backend = "maturin"
 
 [tool.maturin]
@@ -203,8 +203,6 @@ max-complexity = 10
 
 [tool.pytest.ini_options]
 filterwarnings = [
-    # ignore CoolProp warnings for NaN/out of bounds inputs
-    "ignore:CoolProp could not calculate*:UserWarning",
     "ignore::pint.UnitStrippedWarning",
 ]
 
@@ -245,8 +243,8 @@ python-version = "3.13"
 [tool.ty.rules]
 # ty's default rule set is already effectively strict; these are the rules
 # that are not error-by-default, elevated here so `ty check` runs fully strict.
-# NOTE: for forward-compatibility (rules added in future ty versions), CI
-# should additionally pass `--error all`.
+# ty remains advisory in CI while the tool is moving quickly; these local
+# elevations document the intended strictness for manual `ty check` runs.
 redundant-cast = "error"
 possibly-missing-attribute = "error"
 unsupported-dynamic-base = "error"

--- a/rust/src/coolprop.rs
+++ b/rust/src/coolprop.rs
@@ -33,7 +33,7 @@
 use libloading::Library;
 use std::collections::HashSet;
 use std::ffi::{CString, c_char, c_double, c_long};
-use std::sync::{Mutex, RwLock};
+use std::sync::{Mutex, MutexGuard, RwLock, RwLockReadGuard, RwLockWriteGuard};
 
 const BUFLEN: c_long = 1024;
 
@@ -74,6 +74,20 @@ fn cstr(s: &str) -> Result<CString, CpError> {
 fn read_msg(buf: &[c_char]) -> String {
     let bytes: Vec<u8> = buf.iter().take_while(|&&c| c != 0).map(|&c| c as u8).collect();
     String::from_utf8_lossy(&bytes).into_owned()
+}
+
+fn lock_mutex<'a, T>(mutex: &'a Mutex<T>, name: &str) -> Result<MutexGuard<'a, T>, CpError> {
+    mutex.lock().map_err(|_| CpError(format!("{name} lock was poisoned")))
+}
+
+fn read_lock<'a, T>(lock: &'a RwLock<T>, name: &str) -> Result<RwLockReadGuard<'a, T>, CpError> {
+    lock.read()
+        .map_err(|_| CpError(format!("{name} read lock was poisoned")))
+}
+
+fn write_lock<'a, T>(lock: &'a RwLock<T>, name: &str) -> Result<RwLockWriteGuard<'a, T>, CpError> {
+    lock.write()
+        .map_err(|_| CpError(format!("{name} write lock was poisoned")))
 }
 
 /// A loaded libCoolProp + resolved C-API entry points. Cheap to share (`&`)
@@ -180,7 +194,7 @@ impl CoolProp {
     /// (backend, fluid-list) pair, while set_fractions / specify_phase are per-handle
     /// state with no global side effects -- so one warmup per (backend, fluid) covers
     /// every composition and phase of that config.
-    pub fn ensure_warmed_fluid(&self, backend: &str, fluid: &str) {
+    pub fn ensure_warmed_fluid(&self, backend: &str, fluid: &str) -> Result<(), CpError> {
         let key = format!("F\0{backend}\0{fluid}");
         self.ensure_warmed(&key, || {
             if let Ok(mut st) = self.state(backend, fluid)
@@ -189,16 +203,16 @@ impl CoolProp {
                 let mut out = [0.0f64];
                 let _ = st.update_and_1_out(pair, &[101_325.0], &[300.0], okey, &mut out);
             }
-        });
+        })
     }
 
     /// One-time warmup for the humid-air (HAPropsSI) path, so its global init runs
     /// single-threaded before the pool loops HAPropsSI. Keyed once (no per-fluid variation).
-    pub fn ensure_warmed_humid_air(&self) {
+    pub fn ensure_warmed_humid_air(&self) -> Result<(), CpError> {
         self.ensure_warmed("HA", || {
             let mut out = [0.0f64];
             let _ = self.ha_props_si_batch("W", "P", &[101_325.0], "T", &[293.15], "R", &[0.5], &mut out);
-        });
+        })
     }
 
     /// Run `warm` exactly once for `key`. Fast path: a shared read lock + membership test, so
@@ -207,16 +221,17 @@ impl CoolProp {
     /// init, and each new config's backend init completes before any parallel flash of it. No
     /// re-entrancy (warm never calls back here) and no lock-order cycle (warm takes only the
     /// separate handle_lock), so this cannot deadlock.
-    fn ensure_warmed(&self, key: &str, warm: impl FnOnce()) {
-        if self.warmed.read().unwrap().contains(key) {
-            return;
+    fn ensure_warmed(&self, key: &str, warm: impl FnOnce()) -> Result<(), CpError> {
+        if read_lock(&self.warmed, "CoolProp warmup registry")?.contains(key) {
+            return Ok(());
         }
-        let mut warmed = self.warmed.write().unwrap();
+        let mut warmed = write_lock(&self.warmed, "CoolProp warmup registry")?;
         if warmed.contains(key) {
-            return;
+            return Ok(());
         }
         warm();
         warmed.insert(key.to_string());
+        Ok(())
     }
 
     /// Batched humid air: loops the scalar HAPropsSI (no AbstractState handle, no
@@ -257,7 +272,7 @@ impl CoolProp {
         let mut err: c_long = 0;
         let mut msg = [0 as c_char; BUFLEN as usize];
         let handle = {
-            let _g = self.handle_lock.lock().unwrap();
+            let _g = lock_mutex(&self.handle_lock, "CoolProp handle table")?;
             // SAFETY: `b`/`f` are CStrings alive across the call; `err`/`msg` are
             // valid stack buffers (`msg` has BUFLEN bytes). The handle-table write
             // is serialised by `handle_lock` held here.
@@ -365,7 +380,7 @@ impl State<'_> {
 
 impl Drop for State<'_> {
     fn drop(&mut self) {
-        let _g = self.cp.handle_lock.lock().unwrap();
+        let _g = self.cp.handle_lock.lock().unwrap_or_else(|e| e.into_inner());
         let mut err: c_long = 0;
         let mut msg = [0 as c_char; BUFLEN as usize];
         // SAFETY: frees a handle we own exactly once (Drop runs once); the

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -23,6 +23,17 @@ fn perr(e: CpError) -> PolarsError {
     PolarsError::ComputeError(e.0.into())
 }
 
+fn compute_error(msg: impl Into<String>) -> PolarsError {
+    PolarsError::ComputeError(msg.into().into())
+}
+
+fn validate_input_count(kind: &str, got: usize, expected: usize) -> PolarsResult<()> {
+    if got != expected {
+        return Err(compute_error(format!("{kind}: expected {expected} inputs, got {got}")));
+    }
+    Ok(())
+}
+
 /// Broadcast a length-1 input to `n` (Polars passes a scalar `pl.lit` input as
 /// length 1 alongside full columns; map_batches broadcasts via its struct, we
 /// must do it here). No copy when the length already matches.
@@ -37,6 +48,20 @@ fn broadcast(s: &[f64], n: usize) -> PolarsResult<std::borrow::Cow<'_, [f64]>> {
             format!("input length {} incompatible with {n}", s.len()).into(),
         ))
     }
+}
+
+fn broadcast_len(values: &[Vec<f64>], scalar_mask: &[bool]) -> usize {
+    let mut n: Option<usize> = None;
+    for (i, v) in values.iter().enumerate() {
+        if scalar_mask.get(i).copied().unwrap_or(false) {
+            continue;
+        }
+        n = Some(match n {
+            Some(current) => current.max(v.len()),
+            None => v.len(),
+        });
+    }
+    n.unwrap_or_else(|| values.iter().map(Vec::len).max().unwrap_or(0))
 }
 
 /// Materialize a Series as `Vec<f64>` with nulls mapped to NaN. CoolProp turns a NaN
@@ -56,13 +81,16 @@ fn coolprop(lib_path: &str) -> PolarsResult<&'static CoolProp> {
     // load happens once (a plain get/set would let several threads load at once). CoolProp's
     // process-global init is NOT done here -- it is deferred to the first per-config warmup
     // (CoolProp::ensure_warmed_*), so an unused backend is never warmed.
-    let _guard = INIT.lock().unwrap();
+    let _guard = INIT
+        .lock()
+        .map_err(|_| compute_error("CoolProp init lock was poisoned"))?;
     if let Some(c) = CP.get() {
         return Ok(c);
     }
     let c = CoolProp::load(lib_path).map_err(perr)?;
-    let _ = CP.set(c);
-    Ok(CP.get().unwrap())
+    CP.set(c)
+        .map_err(|_| compute_error("CoolProp was initialized concurrently"))?;
+    CP.get().ok_or_else(|| compute_error("CoolProp failed to initialize"))
 }
 
 /// Output dtype preserves the input precision: Float32 only when every non-scalar
@@ -90,6 +118,7 @@ fn output_dtype(dtypes: &[&DataType], scalar_mask: &[bool]) -> DataType {
 }
 
 fn cp_output(input_fields: &[Field], kwargs: EvalKwargs) -> PolarsResult<Field> {
+    validate_input_count("cp_evaluate", input_fields.len(), 2)?;
     let dtypes: Vec<&DataType> = input_fields.iter().map(|f| f.dtype()).collect();
     Ok(Field::new(
         input_fields[0].name().clone(),
@@ -98,6 +127,7 @@ fn cp_output(input_fields: &[Field], kwargs: EvalKwargs) -> PolarsResult<Field> 
 }
 
 fn ha_output(input_fields: &[Field], kwargs: HaKwargs) -> PolarsResult<Field> {
+    validate_input_count("ha_evaluate", input_fields.len(), 3)?;
     let dtypes: Vec<&DataType> = input_fields.iter().map(|f| f.dtype()).collect();
     Ok(Field::new(
         input_fields[0].name().clone(),
@@ -123,9 +153,11 @@ struct EvalKwargs {
 /// over the whole chunk; Polars runs independent properties concurrently.
 #[polars_expr(output_type_func_with_kwargs = cp_output)]
 fn cp_evaluate(inputs: &[Series], kwargs: EvalKwargs) -> PolarsResult<Series> {
+    validate_input_count("cp_evaluate", inputs.len(), 2)?;
+    validate_input_count("cp_evaluate scalar_mask", kwargs.scalar_mask.len(), 2)?;
     let cp = coolprop(&kwargs.lib_path)?;
     // warm THIS (backend, fluid) once, single-threaded, before the parallel flash below
-    cp.ensure_warmed_fluid(&kwargs.backend, &kwargs.fluid);
+    cp.ensure_warmed_fluid(&kwargs.backend, &kwargs.fluid).map_err(perr)?;
     let pair = kwargs.input_pair;
     let okey = cp.param_index(&kwargs.output).map_err(perr)?;
     // decide the output precision from the original input dtypes (before the f64 cast)
@@ -136,9 +168,12 @@ fn cp_evaluate(inputs: &[Series], kwargs: EvalKwargs) -> PolarsResult<Series> {
 
     let v1v = to_f64(&inputs[0])?;
     let v2v = to_f64(&inputs[1])?;
-    let n = v1v.len().max(v2v.len());
-    let v1 = broadcast(&v1v, n)?;
-    let v2 = broadcast(&v2v, n)?;
+    let values = vec![v1v, v2v];
+    let n = broadcast_len(&values, &kwargs.scalar_mask);
+    let v1v = &values[0];
+    let v2v = &values[1];
+    let v1 = broadcast(v1v, n)?;
+    let v2 = broadcast(v2v, n)?;
 
     // state built once per chunk (handle lock held only here), then a lock-free
     // batched flash -> parallel across the independent property expressions.
@@ -176,7 +211,15 @@ mod tests {
         let full = [1.0, 2.0, 3.0];
         assert_eq!(broadcast(&full, 3).unwrap().as_ref(), &full);
         assert_eq!(broadcast(&[7.0], 3).unwrap().as_ref(), &[7.0, 7.0, 7.0]);
+        assert_eq!(broadcast(&[7.0], 0).unwrap().as_ref(), &[] as &[f64]);
         assert!(broadcast(&[1.0, 2.0], 3).is_err());
+    }
+
+    #[test]
+    fn broadcast_len_ignores_scalar_literals() {
+        assert_eq!(broadcast_len(&[vec![1.0], vec![]], &[true, false]), 0);
+        assert_eq!(broadcast_len(&[vec![1.0], vec![2.0, 3.0]], &[true, false]), 2);
+        assert_eq!(broadcast_len(&[vec![1.0], vec![2.0]], &[true, true]), 1);
     }
 
     #[test]
@@ -226,14 +269,16 @@ struct HaKwargs {
 /// expressions parallelize too -- humid air is NOT left to the Python path.
 #[polars_expr(output_type_func_with_kwargs = ha_output)]
 fn ha_evaluate(inputs: &[Series], kwargs: HaKwargs) -> PolarsResult<Series> {
+    validate_input_count("ha_evaluate", inputs.len(), 3)?;
+    validate_input_count("ha_evaluate scalar_mask", kwargs.scalar_mask.len(), 3)?;
     let cp = coolprop(&kwargs.lib_path)?;
-    cp.ensure_warmed_humid_air(); // one-time HAPropsSI global init, single-threaded
+    cp.ensure_warmed_humid_air().map_err(perr)?; // one-time HAPropsSI global init, single-threaded
     let out_dtype = output_dtype(
         &inputs.iter().map(|s| s.dtype()).collect::<Vec<_>>(),
         &kwargs.scalar_mask,
     );
-    let v: Vec<Vec<f64>> = (0..3).map(|i| to_f64(&inputs[i])).collect::<PolarsResult<_>>()?;
-    let n = v[0].len().max(v[1].len()).max(v[2].len());
+    let v: Vec<Vec<f64>> = inputs.iter().take(3).map(to_f64).collect::<PolarsResult<_>>()?;
+    let n = broadcast_len(&v, &kwargs.scalar_mask);
     let (b0, b1, b2) = (broadcast(&v[0], n)?, broadcast(&v[1], n)?, broadcast(&v[2], n)?);
     let mut out = vec![0.0f64; n];
     cp.ha_props_si_batch(

--- a/uv.lock
+++ b/uv.lock
@@ -495,7 +495,7 @@ wheels = [
 
 [[package]]
 name = "encomp"
-version = "1.6.0"
+version = "1.6.1"
 source = { editable = "." }
 dependencies = [
     { name = "coolprop" },
@@ -561,7 +561,7 @@ dev = [
     { name = "hvplot", specifier = ">=0.12.2" },
     { name = "hypothesis" },
     { name = "ipykernel", specifier = ">=7.1.0" },
-    { name = "maturin", specifier = ">=1.5,<2" },
+    { name = "maturin", specifier = ">=1.8.2,<2" },
     { name = "microsoft-python-type-stubs", git = "https://github.com/microsoft/python-type-stubs.git" },
     { name = "myst-parser" },
     { name = "nbsphinx" },


### PR DESCRIPTION
Summary:
- Fix review runtime issues: Quantity validation, in-place operators, derived-dim pickling, gas literals, conversion density validation, and basis-percent parsing.
- Harden CoolProp Python/Rust paths so invalid inputs return Python/Polars errors instead of panics or silent nulls.
- Move doc snippets to pyright, run docs/static source checks in CI, update stale docs, add 1.6.1 release notes, and bump version metadata.

Verification:
- uv run pytest -q
- uv run pyright
- uv run pyrefly check
- uv run ruff check
- cargo check --lib --tests