### PR TITLE
Fix release-readiness findings and release 1.6.3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,8 @@ name: encomp CI/release
 #
 #   typecheck      -> ruff, pyright (strict) + pyrefly, docs build, plus
 #                     source-only doc/static tests (ty is local-only and intentionally not gated)
+#   docs-rtd       -> rebuild the docs in a ReadTheDocs-equivalent environment (no project
+#                     install, no compiled plugin) so an RTD-only break fails the PR
 #   rust           -> cargo fmt, clippy, and in-crate tests
 #   build-wheels   -> one wheel per OS/arch (abi3 cp313 => runs on 3.13+)
 #   test           -> install each prebuilt wheel + run pytest, every OS x py
@@ -56,6 +58,34 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y pandoc
       - run: uv run --no-sync sphinx-build -W -b html docs docs/_build/html
+
+  docs-rtd:
+    # Reproduce the ReadTheDocs build so an RTD-only breakage fails the PR instead of
+    # silently landing (finding: v1.6.2 docs never published because RTD builds broke at
+    # merge and nothing gated them). RTD runs `uv sync --no-install-project`, so the
+    # project and its compiled plugin are NOT installed: autodoc imports encomp from
+    # source (conf.py adds the repo root to sys.path) and the notebooks render their
+    # committed outputs (conf.py sets nbsphinx_execute="never" when READTHEDOCS is set)
+    # rather than executing against a plugin that isn't there. The `typecheck` job above
+    # is the complement -- it installs the plugin and executes the notebooks, gating their
+    # correctness. Keep this job's steps in sync with .readthedocs.yaml.
+    name: docs (ReadTheDocs parity)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          python-version: "3.13"
+      - name: Install pandoc (nbsphinx needs it to render notebooks; present on RTD images)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y pandoc
+      - name: Sync docs tooling WITHOUT installing the project (mirrors .readthedocs.yaml)
+        run: uv sync --locked --all-extras --all-groups --no-install-project
+      - name: Build the docs exactly as ReadTheDocs does (fail on warning)
+        env:
+          READTHEDOCS: "True"
+        run: uv run --no-sync python -m sphinx -T -W --keep-going -b html docs docs/_build/html
 
   rust:
     name: rust fmt/clippy/test
@@ -131,7 +161,7 @@ jobs:
 
   publish:
     name: publish to PyPI
-    needs: [typecheck, rust, build-wheels, test]
+    needs: [typecheck, docs-rtd, rust, build-wheels, test]
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     environment: pypi               # configure the Trusted Publisher against this env

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -18,9 +18,15 @@ build:
       post_install:
          # --no-install-project: install the dependencies + doc tooling (Sphinx, myst-parser,
          # nbsphinx, ...) but do NOT build the Rust extension. conf.py adds the repo root to
-         # sys.path, and importing the encomp modules for autodoc never loads the compiled
-         # plugin (Polars loads it lazily only when an expression is evaluated), so the docs
-         # build without a Rust toolchain or the bundled CoolProp library.
+         # sys.path, so autodoc imports the encomp modules from source without loading the
+         # compiled plugin (Polars loads it lazily only when an expression is evaluated), so
+         # autodoc builds without a Rust toolchain or the bundled CoolProp library.
+         #
+         # The example notebooks are a separate matter: nbsphinx executes each in its own
+         # Jupyter kernel that gets neither the sys.path insert nor an installed encomp, so
+         # they are NOT executed on RTD (conf.py sets nbsphinx_execute="never" when
+         # READTHEDOCS is set) -- their committed outputs are rendered instead. CI executes
+         # the notebooks against the real plugin, which is the notebook-correctness gate.
          - UV_PROJECT_ENVIRONMENT=$READTHEDOCS_VIRTUALENV_PATH uv sync --all-extras --all-groups --no-install-project --link-mode=copy
 
 python:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Documentation](https://readthedocs.org/projects/encomp/badge/?version=latest)](https://encomp.readthedocs.io)
 [![License](https://img.shields.io/pypi/l/encomp.svg)](https://github.com/wlaur/encomp/blob/main/LICENSE)
 
-<img src="https://raw.githubusercontent.com/wlaur/encomp/v1.6.2/docs/img/logo.png" alt="encomp logo" width="150">
+<img src="https://raw.githubusercontent.com/wlaur/encomp/v1.6.3/docs/img/logo.png" alt="encomp logo" width="150">
 
 > General-purpose library for *en*gineering *comp*utations.
 
@@ -362,12 +362,23 @@ uv run pytest
 
 See `encomp/coolprop/README.md` for the plugin build details.
 
+The test suite ships inside the wheel, so an installed `encomp` doubles as its own post-install smoke test (it needs only `pytest` and `hypothesis`):
+
+```bash
+pip install encomp pytest hypothesis
+python -m pytest --pyargs encomp.tests
+```
+
 ## Settings
 
 The attributes of `encomp.settings.Settings` are overridden with a file named `.env` in the current working directory.
 Attribute names are prefixed with `ENCOMP_`.
 Settings are loaded when `encomp.settings` is imported; for runtime changes to quantity and unit rendering, use `encomp.units.set_quantity_format()`.
 
+Because the `.env` file is resolved relative to the current working directory, a stray `.env` that sets an invalid `ENCOMP_*` value (for example `ENCOMP_UNITS` pointing at a missing file) makes `import encomp` fail with a `pydantic.ValidationError`, even in an unrelated project. Remove or correct the offending value; unrelated keys in the `.env` are ignored.
+
 ## Documentation
 
 The usage guide, example notebooks, and API reference are at [encomp.readthedocs.io](https://encomp.readthedocs.io).
+
+Release notes for each version are published as [GitHub Releases](https://github.com/wlaur/encomp/releases).

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,6 +11,7 @@
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 
 
+import os
 import sys
 import tomllib
 from pathlib import Path
@@ -174,7 +175,14 @@ suppress_warnings = [
     "docutils",
 ]
 
-nbsphinx_execute = "always"
+# Execute the example notebooks where the compiled plugin is importable (local dev and
+# CI, which run after `maturin develop`). On ReadTheDocs the project is installed with
+# --no-install-project (.readthedocs.yaml) and nbsphinx runs each notebook in a separate
+# Jupyter kernel that inherits neither conf.py's sys.path insert nor the compiled plugin,
+# so `import encomp` fails there -- render the committed cell outputs instead. CI's
+# `sphinx-build -W` remains the notebook-correctness gate. See CoolProp plugin notes in
+# encomp/coolprop/README.md and the getting-started notebook's committed outputs.
+nbsphinx_execute = "never" if os.environ.get("READTHEDOCS") else "always"
 nbsphinx_allow_errors = False
 
 nbsphinx_requirejs_path = ""

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -67,7 +67,7 @@ mf = Q(25, ureg.kg / ureg.h)
 ### Quantity types
 
 Each dimensionality is a unique subclass of {py:class}`encomp.units.Quantity`.
-The base class itself cannot be instantiated, since it would have no dimensionality at all (a *dimensionless* quantity still has a dimensionality of *1*).
+Every instance is one of these dimensionality subclasses; a plain `Quantity` instance never exists. Calling `Quantity(...)` still works -- the constructor redirects to the subclass matching the unit (a bare number is *dimensionless*, which is itself a dimensionality, of *1*).
 
 ```python
 from encomp.units import Quantity as Q
@@ -196,8 +196,13 @@ Pickling preserves the dimensionality class for module-global dimensionalities. 
 
 ### Custom base dimensionalities
 
-By default, the seven SI dimensionalities (and common combinations of these) are defined, along with some commonly used media (*water*, *air*, *fuel*).
-Additionally, the *normal* dimensionality (used to represent normal volume) and *currency* are defined.
+By default, the seven SI dimensionalities (and common combinations of these) are defined.
+The only *custom* base dimensionalities defined out of the box are *normal* (used to represent normal volume) and *currency*.
+Media dimensionalities such as *dry_air* or *fuel* are not predefined -- create them yourself with {py:func}`encomp.units.define_dimensionality`, as shown below.
+
+:::{warning}
+Do not use *water* as a media tag: `water` is inherited from `pint` as a density unit (`1 kg/liter`), so a unit like `"kg water"` silently parses to `[mass]²/[length]³` instead of raising. Pick an unambiguous name (for example `H2O`) and define it explicitly.
+:::
 
 {py:func}`encomp.units.define_dimensionality` defines a new base dimensionality with a single unit of the same name.
 If the dimensionality already exists, {py:class}`encomp.units.DimensionalityRedefinitionError` is raised.

--- a/encomp/coolprop/__init__.py
+++ b/encomp/coolprop/__init__.py
@@ -694,8 +694,9 @@ def humid_air(
     ).alias(output)  # name the result after the computed property, not the first input
 
 
+@lru_cache(maxsize=1)
 def lib_version() -> str:
-    """CoolProp version of the bundled library."""
+    """CoolProp version of the bundled library (cached; the bundled lib never changes)."""
     import ctypes
 
     lib = ctypes.CDLL(lib_path())

--- a/encomp/fluids.py
+++ b/encomp/fluids.py
@@ -1608,12 +1608,8 @@ class Fluid(CoolPropFluid[MT]):
 
 
 class Water(Fluid[MT]):
-    REPR_PROPERTIES: tuple[tuple[CProperty, str], ...] = (
-        ("P", ".0f"),
-        ("T", ".1f"),
-        ("D", ".1f"),
-        ("V", ".2g"),
-    )
+    # REPR_PROPERTIES is inherited unchanged from CoolPropFluid (P, T, D, V); only the
+    # __repr__ header differs (it shows the phase). HumidAir overrides it, Water does not.
 
     def __init__(self, **kwargs: Unpack[FluidState[MT]]) -> None:
         """

--- a/encomp/tests/test_conversion.py
+++ b/encomp/tests/test_conversion.py
@@ -1,5 +1,6 @@
 from typing import Any, assert_type, cast
 
+import polars as pl
 import pytest
 
 from ..conversion import convert_volume_mass
@@ -46,3 +47,19 @@ def test_convert_volume_mass() -> None:
 
     with pytest.raises(ExpectedDimensionalityError, match="inp"):
         convert_volume_mass(cast(Any, Q(25, "m/s")))
+
+
+def test_convert_volume_mass_polars_series_density() -> None:
+    # a Polars-Series density is validated element-wise (finite and strictly positive),
+    # mirroring the scalar/ndarray guards
+    mass = Q(pl.Series([2.0, 4.0]), "kg")
+
+    vol = convert_volume_mass(mass, rho=Q(pl.Series([1000.0, 2000.0]), "kg/m³"))
+    assert_type(vol, Q[Volume, pl.Series])
+    assert vol.to("m³").m.to_list() == [0.002, 0.002]
+
+    with pytest.raises(ValueError, match="positive"):
+        convert_volume_mass(mass, rho=Q(pl.Series([1000.0, -1.0]), "kg/m³"))
+
+    with pytest.raises(ValueError, match="positive"):
+        convert_volume_mass(mass, rho=Q(pl.Series([1000.0, float("nan")]), "kg/m³"))

--- a/encomp/tests/test_coolprop_plugin.py
+++ b/encomp/tests/test_coolprop_plugin.py
@@ -500,3 +500,14 @@ def test_thread_count_parity() -> None:
         digests[threads] = digest
 
     assert len(set(digests.values())) == 1, f"results differ across thread counts: {digests}"
+
+
+def test_fluid_rejects_unknown_assume_phase() -> None:
+    # assume_phase is a Literal statically, but an out-of-range value passed dynamically
+    # is rejected up front (while building the expression), before any evaluation
+    with pytest.raises(ValueError, match="unknown assumed phase"):
+        cp.fluid("DMASS", "P", "T", assume_phase=cast(Any, "bogus"))
+
+    # a valid assumed phase builds an expression as usual
+    expr = cp.fluid("DMASS", "P", "T", name="HEOS::Water", assume_phase="gas")
+    assert isinstance(expr, pl.Expr)

--- a/encomp/tests/test_fluids.py
+++ b/encomp/tests/test_fluids.py
@@ -288,6 +288,28 @@ def test_incorrect_inputs() -> None:
         Fluid("water", P=Q(2, "bar"), T=Q(25, "°C")).THIS_ATTRIBUTE_DOES_NOT_EXIST
 
 
+def test_wrong_number_of_fixed_points() -> None:
+    # a two-point fluid needs exactly two state inputs; a humid-air state needs three.
+    # These cardinality checks run in __init__, before any CoolProp call.
+    with pytest.raises(ValueError, match="Exactly two fixed points"):
+        Fluid("water", **cast(Any, {"P": Q(1, "bar")}))
+
+    with pytest.raises(ValueError, match="Exactly two fixed points"):
+        Fluid("water", **cast(Any, {"P": Q(1, "bar"), "T": Q(300, "K"), "D": Q(1, "kg/m³")}))
+
+    with pytest.raises(ValueError, match="Exactly two fixed points"):
+        Water(**cast(Any, {"P": Q(1, "bar")}))
+
+    with pytest.raises(ValueError, match="Exactly three fixed points"):
+        HumidAir(**cast(Any, {"P": Q(1, "bar"), "T": Q(25, "degC")}))
+
+
+def test_describe_rejects_unknown_property() -> None:
+    # describe()/search() surface the property catalog; an unknown name is a ValueError
+    with pytest.raises(ValueError, match="not a valid CoolProp property name"):
+        Fluid.describe(cast(Any, "not_a_real_property"))
+
+
 def test_invalid_fluid_repr_does_not_raise() -> None:
     invalid = Fluid(cast(Any, "Watr"), P=Q(2, "bar"), T=Q(25, "degC"))
 

--- a/encomp/tests/test_gases.py
+++ b/encomp/tests/test_gases.py
@@ -150,3 +150,17 @@ def test_normal_volume_legacy_plain_inputs() -> None:
     m_typed = mass_from_normal_volume(nv)
     m_legacy = mass_from_normal_volume(legacy)
     assert m_legacy.to("kg").m == approx(m_typed.to("kg").m, rel=1e-9)
+
+
+def test_convert_gas_volume_rejects_invalid_condition_type() -> None:
+    # a condition that is neither a recognised string ("N"/"S") nor a
+    # (pressure, temperature) tuple is a TypeError, naming the offending argument
+    with pytest.raises(TypeError, match="condition_1"):
+        convert_gas_volume(Q(1.0, "m³"), cast(Any, 123), "N")
+
+    with pytest.raises(TypeError, match="condition_2"):
+        convert_gas_volume(Q(1.0, "m³"), "N", cast(Any, object()))
+
+    # an unrecognised string condition is a ValueError, not a TypeError
+    with pytest.raises(ValueError, match="must be 'N', 'S'"):
+        convert_gas_volume(Q(1.0, "m³"), cast(Any, "X"), "N")

--- a/encomp/tests/test_misc.py
+++ b/encomp/tests/test_misc.py
@@ -104,3 +104,22 @@ def test_isinstance_types_quantity_union() -> None:
     # a union of concrete dimensionalities still narrows correctly
     assert _check(Q[Mass] | Q[Power])
     assert not _check(Q[Power] | Q[Temperature])
+
+
+def test_isinstance_types_non_quantity_union() -> None:
+    # a union of plain (non-Quantity) types is dispatched through isinstance where
+    # possible, and falls back to member-wise checks for parameterized generics that
+    # isinstance cannot evaluate directly
+    def _check(obj: object, expected: object) -> bool:
+        return isinstance_types(obj, cast(Any, expected))
+
+    # plain union: handled by a direct isinstance against the UnionType
+    assert _check(5, int | str)
+    assert _check("x", int | str)
+    assert not _check(5.0, int | str)
+
+    # a union containing a parameterized generic: isinstance(obj, list[int] | dict)
+    # raises TypeError, so isinstance_types decomposes the union member-wise instead
+    assert _check([1, 2, 3], list[int] | dict[str, int])
+    assert _check({"a": 1}, list[int] | dict[str, int])
+    assert not _check((1, 2), list[int] | dict[str, int])

--- a/encomp/tests/test_overloads.py
+++ b/encomp/tests/test_overloads.py
@@ -10,6 +10,7 @@ from ..utypes import (
     Dimensionless,
     Energy,
     EnergyPerMass,
+    Frequency,
     Length,
     Mass,
     MassFlow,
@@ -17,6 +18,7 @@ from ..utypes import (
     Numpy1DArray,
     Numpy1DBoolArray,
     Power,
+    Time,
     UnknownDimensionality,
     Velocity,
     Volume,
@@ -559,3 +561,17 @@ def test_div_known_unknown_all_magnitude_types() -> None:
     assert_type(Q([10.0, 20.0], "kg") / q_unknown, Q[UnknownDimensionality, Numpy1DArray])
     assert_type(Q(pl.Series([10.0, 20.0]), "kg") / q_unknown, Q[UnknownDimensionality, pl.Series])
     assert_type(Q(pl.col("mass"), "kg") / q_unknown, Q[UnknownDimensionality, pl.Expr])
+
+
+def test_frequency_units_infer_statically() -> None:
+    # Frequency (1 / [time]) is now statically constructible from its own unit literals,
+    # so it no longer falls back to UnknownDimensionality like other derived dimensions.
+    assert_type(Q(50, "Hz"), Q[Frequency, float])
+    assert_type(Q(1.0, "kHz"), Q[Frequency, float])
+    assert_type(Q(1.0, "1/s"), Q[Frequency, float])
+    assert_type(Q([1.0, 2.0], "rpm"), Q[Frequency, Numpy1DArray])
+    assert_type(Q(pl.Series([1.0, 2.0]), "MHz"), Q[Frequency, pl.Series])
+
+    # the reciprocal overloads round-trip Time <-> Frequency
+    assert_type(1 / Q(1.0, "s"), Q[Frequency, float])
+    assert_type(1 / Q(1.0, "Hz"), Q[Time, float])

--- a/encomp/tests/test_units.py
+++ b/encomp/tests/test_units.py
@@ -324,13 +324,16 @@ def test_dimensionality_type_hierarchy() -> None:
         class EstimatedDistance(EstimatedLength):
             dimensions = Length.dimensions
 
-        # the Estimation subtype cannot be used directly
-        # it's possible to create the subclass, but not create an instance
+        # the intermediate Estimation subtype cannot carry an instance: the typed
+        # constructor redirects rather than validates, so the dimensionality is taken
+        # from the unit. Q[Estimation](25, "m") therefore produces a plain Quantity[Length]
+        # -- the Estimation marker is dropped, not raised on (documented redirect semantics).
         EstimatedQuantity = Q[Estimation, float]
 
-        # TODO: this does not currently work
-        # with pytest.raises(TypeError):
-        EstimatedQuantity(25, "m")
+        redirected = EstimatedQuantity(25, "m")
+        assert type(redirected) is Q[Length, float]
+        # the intermediate Estimation marker is dropped, not preserved
+        assert not issubclass(cast(Any, redirected)._dimensionality_type, Estimation)
 
         # these quantities are not compatible with normal Length/Mass
         s = Q[EstimatedLength, float](25, "m")
@@ -406,12 +409,12 @@ def test_dimensionality_type_hierarchy() -> None:
         assert_type(s_series, Q[EstimatedLength, pl.Series])
         assert_type(s_series_first, Q[EstimatedLength, float])
 
-        # these quantities are not compatible with normal Length/Mass
-        # TODO: use a more specific exception here
-        with pytest.raises(Exception):  # noqa: B017
+        # these quantities are not compatible with normal Length/Mass: adding a
+        # semantically distinct dimensionality with the same physical dimensions raises
+        with pytest.raises(DimensionalityTypeError):
             _ = cast(Any, s) + Q(25, "m")
 
-        with pytest.raises(Exception):  # noqa: B017
+        with pytest.raises(DimensionalityTypeError):
             _ = m + Q(25, "kg")
 
         # EstimatedDistance is a direct subclass of EstimatedLength, so this works
@@ -917,6 +920,19 @@ def test_check() -> None:
     with pytest.raises(DimensionalityTypeError):
         _ = cast(Any, hv) + epm
 
+    # check() also accepts a Dimensionality *instance* (not only the class), comparing
+    # physical dimensions
+    assert Q(25, "m").check(Length())
+    assert not Q(25, "m").check(Pressure())
+
+    # a raw pint quantity (a PlainQuantity that is not an encomp Quantity) is rejected:
+    # its dimensionality is ambiguous as a check target, so it raises rather than guess
+    import pint
+
+    plain: Any = cast(Any, pint.UnitRegistry()).Quantity(1.0, "meter")
+    with pytest.raises(TypeError, match="Invalid type for dimension"):
+        Q(25, "m").check(plain)
+
 
 def test_typechecked() -> None:
     @typechecked
@@ -1194,18 +1210,18 @@ def test_compatibility() -> None:
 
     q3 = Q[IncompatibleFraction, float](0.2)
 
-    # TODO: use more specific exception here
-
-    with pytest.raises(Exception):  # noqa: B017
+    # IncompatibleFraction shares Dimensionless's physical dimensions but is a distinct
+    # semantic dimensionality, so adding it to a Dimensionless quantity is rejected
+    with pytest.raises(DimensionalityTypeError):
         _ = q3 + q1
 
-    with pytest.raises(Exception):  # noqa: B017
+    with pytest.raises(DimensionalityTypeError):
         _ = q3 + q2
 
-    with pytest.raises(Exception):  # noqa: B017
+    with pytest.raises(DimensionalityTypeError):
         _ = q1 + q3
 
-    with pytest.raises(Exception):  # noqa: B017
+    with pytest.raises(DimensionalityTypeError):
         _ = q2 + q3
 
     s = Q(25, "m")
@@ -1225,10 +1241,10 @@ def test_compatibility() -> None:
     _ = d + d2
     _ = d2 - d
 
-    with pytest.raises(Exception):  # noqa: B017
+    with pytest.raises(DimensionalityTypeError):
         _ = s + d
 
-    with pytest.raises(Exception):  # noqa: B017
+    with pytest.raises(DimensionalityTypeError):
         _ = d - s
 
     assert str(round((Q(25, "MSEK/GWh") * Q(25, "kWh")).to_reduced_units(), 8)) == "0.000625 MSEK"

--- a/encomp/tests/test_utypes.py
+++ b/encomp/tests/test_utypes.py
@@ -1,5 +1,7 @@
 from typing import Literal, get_origin
 
+import pytest
+
 from .. import utypes as ut
 
 _EXPLICIT_UTYPES_EXPORTS = {
@@ -30,3 +32,19 @@ def test_utypes_all_is_complete() -> None:
             expected.add(name)
 
     assert set(ut.__all__) == expected
+
+
+def test_dimensionality_requires_dimensions() -> None:
+    # a non-intermediate Dimensionality subclass must define the `dimensions` attribute.
+    # Building the subclass via type() (rather than a class statement) keeps the failing
+    # definition out of the module namespace; either way it raises inside
+    # __init_subclass__, before the class is ever registered, so the process-wide
+    # dimensionality registry is never mutated.
+    with pytest.raises(TypeError, match="'dimensions' is not defined"):
+        type("_CoverageNoDimensions", (ut.Dimensionality,), {})
+
+
+def test_dimensionality_subclass_dimensions_must_match_parent() -> None:
+    # subclassing a concrete dimensionality with a different `dimensions` is rejected
+    with pytest.raises(TypeError, match="do not match"):
+        type("_CoverageBadChild", (ut.Length,), {"dimensions": ut.Mass.dimensions})

--- a/encomp/units.py
+++ b/encomp/units.py
@@ -85,6 +85,7 @@ from .utypes import (
     Force,
     ForceUnits,
     Frequency,
+    FrequencyUnits,
     HeatTransferCoefficient,
     HeatTransferCoefficientUnits,
     KinematicViscosity,
@@ -862,6 +863,8 @@ class Quantity(
     @overload
     def __new__(cls, val: Sequence[float], unit: TimeUnits) -> Quantity[Time, Numpy1DArray]: ...
     @overload
+    def __new__(cls, val: Sequence[float], unit: FrequencyUnits) -> Quantity[Frequency, Numpy1DArray]: ...
+    @overload
     def __new__(cls, val: Sequence[float], unit: TemperatureUnits) -> Quantity[Temperature, Numpy1DArray]: ...
     @overload
     def __new__(
@@ -959,6 +962,8 @@ class Quantity(
     def __new__(cls, val: MT, unit: MassUnits) -> Quantity[Mass, MT]: ...
     @overload
     def __new__(cls, val: MT, unit: TimeUnits) -> Quantity[Time, MT]: ...
+    @overload
+    def __new__(cls, val: MT, unit: FrequencyUnits) -> Quantity[Frequency, MT]: ...
     @overload
     def __new__(cls, val: MT, unit: TemperatureUnits) -> Quantity[Temperature, MT]: ...
     @overload

--- a/encomp/utypes.py
+++ b/encomp/utypes.py
@@ -173,6 +173,18 @@ TimeUnits = Literal[
     "us",
 ]
 
+# Frequency is the inverse of Time (1 / [time]); it participates in the reciprocal
+# overloads (1 / Time -> Frequency and 1 / Frequency -> Time) so it also gets literal
+# unit spellings, letting Q(50, "Hz") infer Frequency statically like any base dimensionality.
+FrequencyUnits = Literal[
+    "Hz",
+    "kHz",
+    "MHz",
+    "GHz",
+    "rpm",
+    "1/s",
+]
+
 TemperatureUnits = Literal[
     "degC",
     "°C",
@@ -521,6 +533,7 @@ AllUnits = (
     | LengthUnits
     | MassUnits
     | TimeUnits
+    | FrequencyUnits
     | TemperatureUnits
     | TemperatureDifferenceUnits
     | SubstanceUnits
@@ -1126,6 +1139,7 @@ __all__ = [
     "Force",
     "ForceUnits",
     "Frequency",
+    "FrequencyUnits",
     "HeatTransferCoefficient",
     "HeatTransferCoefficientUnits",
     "HeatingValue",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "encomp"
-version = "1.6.2"
+version = "1.6.3"
 description = "General-purpose library for engineering computations"
 authors = [{ name = "William Laurén", email = "lauren.william.a@gmail.com" }]
 requires-python = ">=3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -514,7 +514,7 @@ wheels = [
 
 [[package]]
 name = "encomp"
-version = "1.6.2"
+version = "1.6.3"
 source = { editable = "." }
 dependencies = [
     { name = "coolprop" },


### PR DESCRIPTION
Works through the findings in `REVIEW.md` in order of severity, then bumps the patch version to 1.6.3.

## CRITICAL
- **ReadTheDocs build fixed.** nbsphinx executed the example notebooks in a separate Jupyter kernel that gets neither `conf.py`'s `sys.path` insert nor an installed `encomp` (RTD uses `--no-install-project`), so every RTD build broke from PR #13 onward and the 1.6.2 docs never published. Render committed notebook outputs on RTD (`nbsphinx_execute="never"` when `READTHEDOCS` is set); CI's `sphinx-build -W` (real plugin, executes notebooks) stays the correctness gate. Stale `.readthedocs.yaml` comment updated.

## MAJOR
- **`docs/usage.md` media-dimensionalities claim corrected.** Only `normal` and `currency` are predefined; media dims (`dry_air`/`fuel`) are user-defined via `define_dimensionality()`, and `water` is a pint density unit that can't be used as a media tag.

## MINOR
- **`docs-rtd` CI job** rebuilds the docs in an RTD-equivalent environment (no project install, `READTHEDOCS` set); `publish` now depends on it, so an RTD-only break fails the PR instead of silently landing.
- **`FrequencyUnits`** literal + `__new__` overloads: `Q(50, "Hz")` now infers `Frequency` statically and `Hz` is in `get_registered_units()`.
- **README**: documented the stray-`.env` import-failure footgun.
- **Test-debt cleanup** in `test_units.py`: assert the current redirect behavior instead of a disabled negative test; narrow broad `pytest.raises(Exception)` to `DimensionalityTypeError`.

## NIT
- Reworded the "base class cannot be instantiated" note; `@lru_cache` on `lib_version()`; deleted the redundant `Water.REPR_PROPERTIES`; README changelog pointer (GitHub Releases) + in-wheel test-suite note.

## Tests
- Meaningful public-API tests for previously-uncovered behavior (isinstance_types non-Quantity unions, `convert_volume_mass` Series-density validation, `convert_gas_volume` invalid condition, `Dimensionality` subclass errors, coolprop invalid `assume_phase`, `Quantity.check()` with a `Dimensionality` instance / raw pint quantity, Fluid/Water/HumidAir fixed-point-count validation, `describe()` unknown name, Frequency inference). `conversion`/`gases`/`misc` reach 100%.

## Local verification
- `pyright` (strict): 0 errors. `pyrefly check`: 0 errors (42 suppressed). `ruff check`/`format`: clean.
- `pytest`: 694 passed.
- Docs build clean with `-W` both ways: RTD path (`READTHEDOCS=True`, notebooks not executed) and CI path (notebooks executed with the real plugin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)