### PR TITLE
Gate ty as a third type checker and release 1.7.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,8 +4,8 @@ name: encomp CI/release
 # + bundled libCoolProp, all in one wheel) for macOS / Linux / Windows, run the full
 # test suite against each wheel on Python 3.13 and 3.14, and publish to PyPI on a tag.
 #
-#   typecheck      -> ruff check + format, pyright (strict) + pyrefly, docs build, plus
-#                     source-only doc/static tests (ty is local-only and intentionally not gated)
+#   typecheck      -> ruff check + format, pyright (strict) + pyrefly + ty, docs build,
+#                     plus source-only doc/static tests
 #   docs-rtd       -> rebuild the docs in a ReadTheDocs-equivalent environment (no project
 #                     install, no compiled plugin) so an RTD-only break fails the PR
 #   dependency-floors -> install at the LOWEST versions the declared bounds allow and run the
@@ -38,7 +38,7 @@ jobs:
     # Static source checks run before building the project. The executable docs
     # checks then install the compiled plugin too, so README/usage snippets and
     # notebooks exercise the same public API users get from wheels.
-    name: typecheck (pyright + pyrefly)
+    name: typecheck (pyright + pyrefly + ty)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -51,6 +51,9 @@ jobs:
       - run: uv run --no-sync ruff format --check encomp scripts
       - run: uv run --no-sync pyright
       - run: uv run --no-sync pyrefly check
+      # --error-on-warning: ty's own warnings (e.g. a typo'd rule name in an ignore
+      # comment) must fail the gate, matching how the other two checkers are run
+      - run: uv run --no-sync ty check --error-on-warning
       - name: Build and install the compiled CoolProp plugin for docs execution
         run: |
           python -m pip install cmake

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,9 +51,8 @@ jobs:
       - run: uv run --no-sync ruff format --check encomp scripts
       - run: uv run --no-sync pyright
       - run: uv run --no-sync pyrefly check
-      # --error-on-warning: ty's own warnings (e.g. a typo'd rule name in an ignore
-      # comment) must fail the gate, matching how the other two checkers are run
-      - run: uv run --no-sync ty check --error-on-warning
+      # ty's warnings fail the gate too: error-on-warning is set in [tool.ty.terminal]
+      - run: uv run --no-sync ty check
       - name: Build and install the compiled CoolProp plugin for docs execution
         run: |
           python -m pip install cmake

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,10 @@ jobs:
     # Static source checks run before building the project. The executable docs
     # checks then install the compiled plugin too, so README/usage snippets and
     # notebooks exercise the same public API users get from wheels.
-    name: typecheck (pyright + pyrefly + ty)
+    # the job name is pinned by branch protection (required status checks match on the
+    # exact name), so it stays as-is even though the job now gates on ty as well;
+    # renaming it requires updating the required checks on main in the same change
+    name: typecheck (pyright + pyrefly)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ CI gates on **pyright (strict), pyrefly and ty** — all three must pass with ze
 ```bash
 uv run pyright
 uv run pyrefly check
-uv run ty check --error-on-warning
+uv run ty check
 ```
 
 Rules of engagement:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,95 @@
+# Working on encomp
+
+encomp is a typed units/quantities library for process engineering: a pint-based
+`Quantity[DT, MT]` generic over dimensionality (`DT`, e.g. `Pressure`) and magnitude type
+(`MT`: `float`, 1-D `np.ndarray`, `pl.Series` or `pl.Expr`), plus CoolProp fluid
+properties (`encomp.fluids`) with a native Rust Polars plugin for GIL-free parallel
+evaluation. The [README](README.md) covers the user-facing API; this file covers the
+conventions that are easy to get wrong when changing the code.
+
+## Three type checkers, one verdict
+
+CI gates on **pyright (strict), pyrefly and ty** — all three must pass with zero errors:
+
+```bash
+uv run pyright
+uv run pyrefly check
+uv run ty check --error-on-warning
+```
+
+Rules of engagement:
+
+- **pyright is the primary checker and the source of truth.** When checkers disagree,
+  the code stays as pyright wants it and the disagreeing checker is suppressed on that
+  line. Never restructure working code just to appease pyrefly or ty — but do prefer a
+  real code improvement over a suppression when one exists that all three accept.
+- **Suppressions are per-checker and rule-specific.** Blanket `# type: ignore` is
+  disabled for pyright (`enableTypeIgnoreComments = false`) and effectively banned
+  everywhere. Each checker only sees its own directive, so they stack on one line:
+
+  ```text
+  def check(  # pyright: ignore[reportIncompatibleMethodOverride]  # pyrefly: ignore[bad-override]  # ty: ignore[invalid-method-override]
+  ```
+
+- **Unused suppressions are errors in all three** (`reportUnnecessaryTypeIgnoreComment`,
+  `unused-ignore`, `unused-ignore-comment`), so a fixed ignore must be deleted in the
+  same change that fixes it.
+- Typical reasons a ty-only ignore exists (pyright and pyrefly accept the same line):
+  constrained-TypeVar solving on `MT`, TypeVar defaults materialized during `isinstance`
+  narrowing, and `float`-vs-`int | float` promotion making a pyright-required `cast()`
+  look redundant. Do not "fix" these by weakening annotations or removing casts —
+  removing a cast that pyright strict needs to launder `Unknown` fails the pyright gate.
+- `Q("24 kg")` (string magnitude) and `Q(1, Q(2, "m"))` (Quantity as unit) must be
+  rejected *statically by all three checkers* and at runtime;
+  `encomp/tests/test_static_typing.py` pins this. Don't add overloads that would let
+  either slip through.
+
+## Documentation is executed
+
+Every ` ```python ` fence in every Markdown file in the repo — including this one — is
+extracted by `encomp/tests/test_docs.py`, ruff-checked, type-checked by all three
+checkers and **run in isolation**. There is no skip or no-run escape. A doc block must
+carry its own imports and pass the same gates as source code:
+
+```python
+from encomp.units import Quantity as Q
+
+pressure = Q(1.0, "bar")
+assert pressure.to("kPa").m == 100.0
+```
+
+## Library invariants
+
+- **Magnitude and unit are always separate arguments.** No string parsing of
+  quantities, anywhere, including docs and tests.
+- **No implicit physical identities.** A fluid name, density or similar physical
+  identity is never defaulted — APIs require it explicitly (`cp.fluid(name=...)`;
+  `cp.water()` exists for the common case). Don't add parameter defaults that encode
+  physics.
+- `bool` magnitudes are rejected at runtime (a bool is always a mistake), `int`
+  magnitudes normalize to `float`, and only 1-D arrays are accepted.
+- `Temperature` and `TemperatureDifference` are distinct dimensionalities with
+  deliberate arithmetic (`T - T -> ΔT`, `T ± ΔT -> T`, `ΔT - T` is an error). The
+  comparison and pickling overrides on `Quantity` intentionally narrow pint's
+  signatures — that's the point of the library, not an LSP bug to fix.
+- CoolProp evaluation is **one property per DAG node** by design; don't batch multiple
+  output properties into one plugin call. All CoolProp paths hold the GIL — the Rust
+  plugin (`rust/`) exists precisely to evaluate without it; don't add Python-side
+  parallelism around CoolProp.
+
+## Tooling
+
+- `uv` with a committed lockfile (`uv sync --locked`); `ruff check` + `ruff format`
+  (enforced by pre-commit and CI).
+- Mixed Python + Rust project built with maturin. Development checkouts build the
+  plugin locally: `python scripts/build_libcoolprop.py` then
+  `uv run maturin develop --release` (see `encomp/coolprop/README.md`).
+- Tests: `uv run pytest`. The suite ships in the wheel and must stay runnable from an
+  installed package (checker-dependent tests skip when the tool is absent).
+- CI (`.github/workflows/release.yml`): typecheck (ruff + all three checkers + doc
+  execution), ReadTheDocs-parity docs build, dependency floors (lowest allowed versions
+  on Python 3.13 — validate new floors on the newest Python too), Rust checks, wheels
+  per OS, and tag-triggered PyPI publish.
+- Release: bump the version in `pyproject.toml` *and* `uv.lock`, PR, then tag
+  `v<version>`; the workflow publishes to PyPI and creates the GitHub Release. Delete
+  merged branches.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -660,7 +660,7 @@ phase_names = Water.PHASES
 
 # when one input is constant (float, int, single element array),
 # it's repeated as an array
-Water(T=Q(np.linspace(25, 500, 10), "°C"), P=Q(5, "bar"))
+Water(T=Q(np.linspace(25, 500, 10), "°C"), P=Q(5, "bar"))  # ty: ignore[invalid-argument-type]
 # <Water (Variable), P=[500 500 500 ...] kPa, T=[25.0 77.8 130.6 ...] °C,
 # D=[997.2 973.4 934.5 ...] kg/m³, V=[0.89 0.36 0.21 ...] cP>
 ```

--- a/encomp/fluids.py
+++ b/encomp/fluids.py
@@ -334,7 +334,7 @@ class CoolPropFluid(ABC, Generic[MT]):  # noqa: UP046
     # fractions, one float per species. When not None, evaluation uses the
     # low-level AbstractState API (PropsSI cannot take an explicit composition).
     # None means the composition is fixed in the fluid name, or the fluid is pure.
-    _composition: dict[str, float] | None = None
+    _composition: Composition | None = None
 
     # True when an assumed phase or a composition is configured, i.e. evaluation
     # must use the low-level AbstractState path. A single flag so the normal
@@ -943,7 +943,7 @@ class CoolPropFluid(ABC, Generic[MT]):  # noqa: UP046
                 exprs[1].alias(n2),
                 name=self.name,
                 assume_phase=cast("AssumedPhase | None", self._assumed_phase),
-                composition=cast("Composition | None", self._composition),
+                composition=self._composition,
             )
         return expr.alias(output)
 
@@ -1227,8 +1227,7 @@ class CoolPropFluid(ABC, Generic[MT]):  # noqa: UP046
 
         if isinstance(qty.m, pl.Series):
             # missing values surface as null, never NaN (the library's single sentinel)
-            qty.m = qty.m.fill_nan(None)
-            qty.m = cast(Any, qty.m).cast(self._eager_series_output_dtype())
+            qty.m = qty.m.fill_nan(None).cast(self._eager_series_output_dtype())
 
         return cast("Quantity[Any, MT]", qty)
 

--- a/encomp/fluids.py
+++ b/encomp/fluids.py
@@ -854,7 +854,7 @@ class CoolPropFluid(ABC, Generic[MT]):  # noqa: UP046
 
         def to_arr(m: float | Numpy1DArray | pl.Expr) -> Numpy1DArray:
             if isinstance(m, np.ndarray):
-                return m.flatten().astype(float)
+                return m.flatten().astype(float)  # ty: ignore[invalid-argument-type, unresolved-attribute]
             return np.full(n, cast("float", m))
 
         p1_arr, p2_arr = to_arr(p1), to_arr(p2)
@@ -997,7 +997,7 @@ class CoolPropFluid(ABC, Generic[MT]):  # noqa: UP046
     @staticmethod
     def _reduce_single_element(x: float | Numpy1DArray | pl.Expr) -> float | Numpy1DArray | pl.Expr:
         if isinstance(x, np.ndarray) and x.size == 1:
-            return float(x[0])
+            return float(x[0])  # ty: ignore[invalid-argument-type]
         return x
 
     def evaluate_single(self, output: CProperty, *points: tuple[CProperty, float]) -> float:
@@ -1183,7 +1183,7 @@ class CoolPropFluid(ABC, Generic[MT]):  # noqa: UP046
 
         def expand_scalars(x: float | np.ndarray) -> Numpy1DArray:
             if isinstance(x, np.ndarray):
-                return x
+                return x  # ty: ignore[invalid-return-type]
 
             return np.repeat(x, n).astype(float).reshape(shape)
 
@@ -1223,7 +1223,7 @@ class CoolPropFluid(ABC, Generic[MT]):  # noqa: UP046
             qty.ito(ret_unit)
 
         if convert_magnitude:
-            qty = qty.astype(self._mt)
+            qty = qty.astype(self._mt)  # ty: ignore[no-matching-overload]
 
         if isinstance(qty.m, pl.Series):
             # missing values surface as null, never NaN (the library's single sentinel)
@@ -1484,7 +1484,7 @@ class Fluid(CoolPropFluid[MT]):
             # a NaN row is an invalid state, not a phase, so the phase is judged on the rows that
             # have one. Reducing over the raw array would instead count each NaN as its own
             # distinct phase, since nan != nan
-            finite = cast("Numpy1DArray", phase_idx_val[np.isfinite(phase_idx_val)])
+            finite = cast("Numpy1DArray", phase_idx_val[np.isfinite(phase_idx_val)])  # ty: ignore[invalid-argument-type]
 
             if finite.size == 0:
                 return "N/A"

--- a/encomp/gases.py
+++ b/encomp/gases.py
@@ -84,7 +84,9 @@ def _resolve_gas_condition(condition: object, name: str) -> GasCondition:
     if not isinstance(condition, tuple):
         raise TypeError(f"{name} must be 'N', 'S', or a (pressure, temperature) tuple, got {condition!r}")
 
-    condition_tuple = cast("tuple[object, ...]", condition)
+    # cast, not an annotation: pyright strict needs the Unknown tuple elements laundered,
+    # which only cast() does; ty resolves the same type on its own and calls this redundant
+    condition_tuple = cast("tuple[object, ...]", condition)  # ty: ignore[redundant-cast]
     if len(condition_tuple) != 2:
         raise TypeError(f"{name} must be 'N', 'S', or a (pressure, temperature) tuple, got {condition!r}")
 

--- a/encomp/gases.py
+++ b/encomp/gases.py
@@ -77,7 +77,7 @@ _NORMAL = Quantity(1.0, "normal")
 def _resolve_gas_condition(condition: object, name: str) -> GasCondition:
     if isinstance(condition, str):
         if condition in ("N", "S"):
-            return _n_s_condition(condition)
+            return _n_s_condition(condition)  # ty: ignore[invalid-argument-type]
 
         raise ValueError(f"{name} must be 'N', 'S', or a (pressure, temperature) tuple, got {condition!r}")
 
@@ -138,7 +138,7 @@ def ideal_gas_density(
 
     # directly from ideal gas law
     # override the inferred type here since it's sure to be Density
-    rho = (P * M) / (CONSTANTS.R * T.to("K").unknown())
+    rho = (P * M) / (CONSTANTS.R * T.to("K").unknown())  # ty: ignore[unsupported-operator]
 
     return rho.to("kg/m³").asdim(Density)
 

--- a/encomp/misc.py
+++ b/encomp/misc.py
@@ -90,7 +90,9 @@ def isinstance_types[T](obj: Any, expected: TypeForm[T]) -> TypeIs[T]:  # noqa: 
         # index 1, which is exactly the error this library exists to catch. The linear cost
         # is irrelevant here -- encomp's own hot-path calls pass scalar quantities, never
         # collections
-        check_type(cast(Any, obj), expected, collection_check_strategy=CollectionCheckStrategy.ALL_ITEMS)
+        # cast(Any) launders the partially-unknown narrowed type for pyright strict;
+        # ty already sees plain Any here and calls the cast redundant
+        check_type(cast(Any, obj), expected, collection_check_strategy=CollectionCheckStrategy.ALL_ITEMS)  # ty: ignore[redundant-cast]
         return True
     except TypeCheckError:
         # only a genuine type mismatch answers False -- an invalid ``expected``

--- a/encomp/sympy.py
+++ b/encomp/sympy.py
@@ -321,7 +321,7 @@ def get_lambda_kwargs(
 
     def _get_val(
         x: Quantity[Any, Numpy1DArray] | Numpy1DArray,
-    ) -> Quantity | Numpy1DArray | float:
+    ) -> Quantity[Any, Numpy1DArray] | Numpy1DArray | float:
         if not isinstance(x, Quantity):
             return x
 
@@ -537,6 +537,8 @@ def substitute_unknowns(
     if avoid is None:
         avoid = set()
 
+    excluded = knowns | avoid
+
     replacements: list[tuple[sp.Symbol, sp.Basic]] = []
 
     def _get_unknowns(expr: sp.Basic) -> list[sp.Symbol]:
@@ -544,7 +546,7 @@ def substitute_unknowns(
 
         already_replaced = [m[0] for m in replacements]
 
-        return [n for n in all_symbols if n not in (knowns | avoid) and n not in already_replaced]
+        return [n for n in all_symbols if n not in excluded and n not in already_replaced]
 
     unknowns_list = _get_unknowns(e)
 

--- a/encomp/tests/test_builtins.py
+++ b/encomp/tests/test_builtins.py
@@ -25,8 +25,8 @@ def test_abs() -> None:
 
 
 def test_min_max() -> None:
-    assert_type(min(Q([25], "kg")), Q[Mass, float])
-    assert_type(max(Q([25], "kg")), Q[Mass, float])
+    assert_type(min(Q([25], "kg")), Q[Mass, float])  # ty: ignore[type-assertion-failure]
+    assert_type(max(Q([25], "kg")), Q[Mass, float])  # ty: ignore[type-assertion-failure]
 
     # min/max iterate, and a pl.Series magnitude (the polars world) is not
     # iterable as a Quantity -- the reduction belongs on the magnitude (.m)

--- a/encomp/tests/test_docs.py
+++ b/encomp/tests/test_docs.py
@@ -1,6 +1,6 @@
 """Every ``python`` code block in the docs must be self-contained: it carries its own
-imports, is clean under ``ruff check``, type-checks under ``pyright`` and ``pyrefly``,
-and runs without error in isolation.
+imports, is clean under ``ruff check``, type-checks under ``pyright``, ``pyrefly`` and
+``ty``, and runs without error in isolation.
 
 This guards the documentation against drift -- a renamed API, a missing import, or a
 snippet that only worked as a continuation of an earlier block all fail here. The block
@@ -73,6 +73,7 @@ ROOT = _repo_root()
 _RUFF = _tool("ruff")
 _PYRIGHT = _tool("pyright")
 _PYREFLY = _tool("pyrefly")
+_TY = _tool("ty")
 
 pytestmark = pytest.mark.skipif(
     ROOT is None, reason="docs sources not on disk (installed wheel) -- source-tree check only"
@@ -182,6 +183,24 @@ def test_doc_block_typechecks_pyrefly(code: str, tmp_path: Path) -> None:
         cwd=ROOT,
     )
     assert proc.returncode == 0, f"pyrefly failed:\n{proc.stdout}{proc.stderr}"
+
+
+@pytest.mark.skipif(_TY is None, reason="ty not installed")
+@pytest.mark.parametrize("code", _CODES, ids=_IDS)
+def test_doc_block_typechecks_ty(code: str, tmp_path: Path) -> None:
+    assert _TY is not None  # narrowed by the skipif above
+    assert ROOT is not None  # narrowed by the module-level skipif
+    block = tmp_path / "block.py"
+    block.write_text(code)
+    proc = subprocess.run(
+        # --project resolves the repo's [tool.ty] config and venv even though the
+        # block itself lives in tmp_path; --error-on-warning matches the CI gate
+        [_TY, "check", "--project", str(ROOT), "--error-on-warning", str(block)],
+        capture_output=True,
+        text=True,
+        cwd=ROOT,
+    )
+    assert proc.returncode == 0, f"ty failed:\n{proc.stdout}{proc.stderr}"
 
 
 @pytest.mark.parametrize("code", _CODES, ids=_IDS)

--- a/encomp/tests/test_docs.py
+++ b/encomp/tests/test_docs.py
@@ -193,9 +193,9 @@ def test_doc_block_typechecks_ty(code: str, tmp_path: Path) -> None:
     block = tmp_path / "block.py"
     block.write_text(code)
     proc = subprocess.run(
-        # --project resolves the repo's [tool.ty] config and venv even though the
-        # block itself lives in tmp_path; --error-on-warning matches the CI gate
-        [_TY, "check", "--project", str(ROOT), "--error-on-warning", str(block)],
+        # --project resolves the repo's [tool.ty] config (including its
+        # error-on-warning gate) and venv even though the block lives in tmp_path
+        [_TY, "check", "--project", str(ROOT), str(block)],
         capture_output=True,
         text=True,
         cwd=ROOT,

--- a/encomp/tests/test_examples.py
+++ b/encomp/tests/test_examples.py
@@ -346,5 +346,5 @@ class TestUsageExamples:
         assert isinstance(phases.m, np.ndarray)
 
         # Constant input
-        water_const_p = Water(T=Q(np.linspace(25, 500, 10), "°C"), P=Q(5, "bar"))
+        water_const_p = Water(T=Q(np.linspace(25, 500, 10), "°C"), P=Q(5, "bar"))  # ty: ignore[invalid-argument-type]
         assert isinstance(water_const_p.D.m, np.ndarray)

--- a/encomp/tests/test_fluids.py
+++ b/encomp/tests/test_fluids.py
@@ -81,10 +81,10 @@ def test_Fluid() -> None:
     repr(Water(T=Q(np.inf, "degC"), Q=Q(0.9)))
     repr(Water(T=Q(-np.inf, "degC"), Q=Q(0.9)))
 
-    repr(Water(T=Q([np.nan, np.nan], "degC"), Q=Q(0.9)))
-    repr(Water(T=Q([np.inf, np.inf], "degC"), Q=Q(0.9)))
-    repr(Water(T=Q([-np.inf, -np.inf], "degC"), Q=Q(0.9)))
-    repr(Water(T=Q([-np.inf, np.inf], "degC"), Q=Q(0.9)))
+    repr(Water(T=Q([np.nan, np.nan], "degC"), Q=Q(0.9)))  # ty: ignore[invalid-argument-type]
+    repr(Water(T=Q([np.inf, np.inf], "degC"), Q=Q(0.9)))  # ty: ignore[invalid-argument-type]
+    repr(Water(T=Q([-np.inf, -np.inf], "degC"), Q=Q(0.9)))  # ty: ignore[invalid-argument-type]
+    repr(Water(T=Q([-np.inf, np.inf], "degC"), Q=Q(0.9)))  # ty: ignore[invalid-argument-type]
 
     with pytest.raises(ValueError):
         # cannot fix all of P, T, Q
@@ -108,10 +108,10 @@ def test_Fluid() -> None:
     Fluid("water", T=Q([25, np.nan], "°C"), P=Q([1, 2], "bar")).H
     Fluid("water", T=Q([np.nan, np.nan], "°C"), P=Q([1, 2], "bar")).H
     Fluid("water", T=Q([np.nan, np.nan], "°C"), P=Q([np.nan, np.nan], "bar")).H
-    Fluid("water", P=Q([1, 2], "bar"), T=Q(23, "°C")).H
-    Fluid("water", P=Q([1], "bar"), T=Q(23, "°C")).H
+    Fluid("water", P=Q([1, 2], "bar"), T=Q(23, "°C")).H  # ty: ignore[invalid-argument-type]
+    Fluid("water", P=Q([1], "bar"), T=Q(23, "°C")).H  # ty: ignore[invalid-argument-type]
     Fluid("water", T=Q([23, 25], "°C"), P=Q([1], "bar")).H
-    Fluid("water", T=Q([23, 25], "°C"), P=Q(np.nan, "bar")).H
+    Fluid("water", T=Q([23, 25], "°C"), P=Q(np.nan, "bar")).H  # ty: ignore[invalid-argument-type]
     Fluid("water", T=Q([23, 25], "°C"), P=Q([1, np.nan], "bar")).H
 
     Water(T=Q([25, 25, 63], "°C"), Q=Q([np.nan, np.nan, 0.4], "")).H
@@ -132,7 +132,7 @@ def test_Fluid() -> None:
 
     assert isinstance(ret, np.ndarray) and ret.size == 2
 
-    ret = Water(P=Q([2, 3], "bar"), Q=Q(0.5)).D.m
+    ret = Water(P=Q([2, 3], "bar"), Q=Q(0.5)).D.m  # ty: ignore[invalid-argument-type]
 
     assert isinstance(ret, np.ndarray) and ret.size == 2
 
@@ -140,11 +140,11 @@ def test_Fluid() -> None:
 
     assert isinstance(ret, np.ndarray) and ret.size == 1
 
-    ret = Water(P=Q([2], "bar"), Q=Q(0.5)).D.m
+    ret = Water(P=Q([2], "bar"), Q=Q(0.5)).D.m  # ty: ignore[invalid-argument-type]
 
     assert isinstance(ret, np.ndarray) and ret.size == 1
 
-    ret = Water(Q=Q([0.5]), P=Q(2, "bar")).D.m
+    ret = Water(Q=Q([0.5]), P=Q(2, "bar")).D.m  # ty: ignore[invalid-argument-type]
 
     assert isinstance(ret, np.ndarray) and ret.size == 1
 
@@ -167,9 +167,9 @@ def test_Fluid() -> None:
     # returns 1-element list
     assert isinstance(Fluid("water", T=Q([23], "°C"), P=Q([1], "bar")).H.m, np.ndarray)
 
-    assert isinstance(Fluid("water", P=Q([1], "bar"), T=Q(23, "°C")).H.m, np.ndarray)
+    assert isinstance(Fluid("water", P=Q([1], "bar"), T=Q(23, "°C")).H.m, np.ndarray)  # ty: ignore[invalid-argument-type]
 
-    assert isinstance(Fluid("water", T=Q([23], "°C"), P=Q(1, "bar")).H.m, np.ndarray)
+    assert isinstance(Fluid("water", T=Q([23], "°C"), P=Q(1, "bar")).H.m, np.ndarray)  # ty: ignore[invalid-argument-type]
 
     # returns float
     assert isinstance(Fluid("water", T=Q(23, "°C"), P=Q(1, "bar")).H.m, float)
@@ -268,10 +268,10 @@ def test_incorrect_inputs() -> None:
         Fluid("water", P=Q(cast(Any, p), "bar"), T=Q(t, "degC")).D
 
     with pytest.raises(ValueError):
-        Fluid("water", P=Q(cast(Any, p), "bar"), T=Q(t, "degC"), H=Q(25, "kJ/kg"))
+        Fluid("water", P=Q(cast(Any, p), "bar"), T=Q(t, "degC"), H=Q(25, "kJ/kg"))  # ty: ignore[invalid-argument-type]
 
     with pytest.raises(ValueError):
-        Water(P=Q(cast(Any, p), "bar"), T=Q(t, "degC"), H=Q(25, "kJ/kg"))
+        Water(P=Q(cast(Any, p), "bar"), T=Q(t, "degC"), H=Q(25, "kJ/kg"))  # ty: ignore[invalid-argument-type]
 
     with pytest.raises(ValueError):
         Water(P=Q(cast(Any, p), "bar"))
@@ -355,7 +355,7 @@ def test_Water() -> None:
     assert "V=0.0 cP" not in steam_repr
     assert "V=0.013 cP" in steam_repr
 
-    water_multi = Water(T=Q(np.linspace(25, 50), "°C"), P=Q(5, "bar"))
+    water_multi = Water(T=Q(np.linspace(25, 50), "°C"), P=Q(5, "bar"))  # ty: ignore[invalid-argument-type]
 
     repr(water_multi)
 
@@ -381,7 +381,7 @@ def test_HumidAir() -> None:
     P = Q(20, "bar")
     R = Q(20, "%")
 
-    ha = HumidAir(T=T, P=P, R=R)
+    ha = HumidAir(T=T, P=P, R=R)  # ty: ignore[invalid-argument-type]
     ha.V
 
     T = Q([25, 34], "°C")
@@ -582,8 +582,8 @@ def test_polars_fluids() -> None:
     w_series = Water(P=Q(pl.Series([1, 2, 3]), "bar"), T=Q(pl.Series([150, 250, 350]), "degC"))
     assert_type(w_series.D, Q[ut.Density, pl.Series])  # pyrefly: ignore[assert-type]
 
-    w_series_const_T = Water(P=Q(pl.Series([1, 2, 3]), "bar"), T=Q(150, "degC"))
-    assert_type(w_series_const_T.D, Q[ut.Density, pl.Series])  # pyrefly: ignore[assert-type]
+    w_series_const_T = Water(P=Q(pl.Series([1, 2, 3]), "bar"), T=Q(150, "degC"))  # ty: ignore[invalid-argument-type]
+    assert_type(w_series_const_T.D, Q[ut.Density, pl.Series])  # pyrefly: ignore[assert-type]  # ty: ignore[type-assertion-failure]
 
     mixed_container = Water(
         P=Q(np.array([1.0, 2.0, 3.0]), "bar"),
@@ -607,7 +607,7 @@ def test_polars_fluids() -> None:
 
     assert D.is_null().all()
 
-    repr(Water(P=Q(pl.lit(5), "bar"), T=Q(50, "degC")))
+    repr(Water(P=Q(pl.lit(5), "bar"), T=Q(50, "degC")))  # ty: ignore[invalid-argument-type]
 
     with pytest.raises(TypeError):
         Water(P=Q(pl.lit(5), "bar"), T=cast(Any, Q([1, 2, 3], "degC"))).D

--- a/encomp/tests/test_resolve_fluid_spec.py
+++ b/encomp/tests/test_resolve_fluid_spec.py
@@ -85,7 +85,7 @@ def test_invalid_composition(name: str, composition: dict[str, float], match: st
 def test_composition_rejects_non_float_fractions() -> None:
     # bool is an int subclass, so it would otherwise slip through as 1.0
     with pytest.raises(TypeError, match="must be a float"):
-        cp.resolve_fluid_spec("HEOS", composition=cast("cp.Composition", {"CO2": True, "O2": 0.5}))
+        cp.resolve_fluid_spec("HEOS", composition=cast("cp.Composition", {"CO2": True, "O2": 0.5}))  # ty: ignore[redundant-cast]
 
     with pytest.raises(TypeError, match="must be a float"):
         cp.resolve_fluid_spec("HEOS", composition=cast("cp.Composition", {"CO2": "0.7", "O2": 0.3}))

--- a/encomp/tests/test_rust_parity.py
+++ b/encomp/tests/test_rust_parity.py
@@ -126,8 +126,9 @@ def test_rust_python_parity_input_pairs() -> None:
 
         def density(mode: str, second: str = second, unit: str = unit, df: pl.DataFrame = df) -> np.ndarray:
             clear_expr_evaluation_cache()
+            second_point: dict[str, Any]
             if mode == "rust":
-                second_point: dict[str, Any] = {second: Q(pl.col(second), unit)}
+                second_point = {second: Q(pl.col(second), unit)}
                 fluid = Fluid("HEOS::Water", P=Q(pl.col("P"), "Pa"), **second_point)
                 return df.select(fluid.D.m.alias("d"))["d"].to_numpy().astype(float)
             second_point = {second: Q(df[second].to_numpy(), unit)}

--- a/encomp/tests/test_static_typing.py
+++ b/encomp/tests/test_static_typing.py
@@ -7,8 +7,8 @@ type checkers, not just the runtime.
   fallback overload excludes it from the unit types.
 
 The runtime rejects both (``_validate_magnitude`` / ``__new__``); these tests additionally
-pin the *static* rejection through the fallback ``Quantity.__new__`` overload, under both
-pyright and pyrefly. A valid twin snippet is checked as a control, so a failure of the
+pin the *static* rejection through the fallback ``Quantity.__new__`` overload, under
+pyright, pyrefly and ty. A valid twin snippet is checked as a control, so a failure of the
 invalid snippet cannot be explained away by import-resolution problems.
 """
 
@@ -34,6 +34,7 @@ def _tool(name: str) -> str | None:
 
 _PYREFLY = _tool("pyrefly")
 _PYRIGHT = _tool("pyright")
+_TY = _tool("ty")
 
 _VALID = """
 from encomp.units import Quantity as Q
@@ -108,6 +109,15 @@ def test_string_input_rejected_by_pyright(tmp_path: Path) -> None:
     assert _check([_PYRIGHT], _INVALID, tmp_path) != 0, "string inputs must not type-check"
 
 
+@pytest.mark.skipif(_TY is None, reason="ty not installed")
+@pytest.mark.skipif(_ROOT is None, reason=_NO_CONFIG)
+def test_string_input_rejected_by_ty(tmp_path: Path) -> None:
+    assert _TY is not None  # narrowed by the skipif above
+    cmd = [_TY, "check"]
+    assert _check(cmd, _VALID, tmp_path) == 0, "control snippet must type-check"
+    assert _check(cmd, _INVALID, tmp_path) != 0, "string inputs must not type-check"
+
+
 def test_string_input_rejected_at_runtime() -> None:
     with pytest.raises(ValueError):
         Q(cast(Any, "24 kg"))
@@ -131,6 +141,15 @@ def test_quantity_unit_rejected_by_pyright(tmp_path: Path) -> None:
     assert _PYRIGHT is not None  # narrowed by the skipif above
     assert _check([_PYRIGHT], _VALID_UNIT, tmp_path) == 0, "control snippet must type-check"
     assert _check([_PYRIGHT], _INVALID_UNIT, tmp_path) != 0, "a Quantity unit must not type-check"
+
+
+@pytest.mark.skipif(_TY is None, reason="ty not installed")
+@pytest.mark.skipif(_ROOT is None, reason=_NO_CONFIG)
+def test_quantity_unit_rejected_by_ty(tmp_path: Path) -> None:
+    assert _TY is not None  # narrowed by the skipif above
+    cmd = [_TY, "check"]
+    assert _check(cmd, _VALID_UNIT, tmp_path) == 0, "control snippet must type-check"
+    assert _check(cmd, _INVALID_UNIT, tmp_path) != 0, "a Quantity unit must not type-check"
 
 
 def test_quantity_unit_rejected_at_runtime() -> None:

--- a/encomp/tests/test_transforms.py
+++ b/encomp/tests/test_transforms.py
@@ -632,7 +632,7 @@ def _dynamic(*q: Q[DT]) -> Q[DT]:
 
 def test_dynamic() -> None:
     v = _dynamic(Q([25], "kg"), Q([25], "kg"))  # pyrefly: ignore[bad-argument-type]
-    assert_type(v, Q[Mass, np.ndarray])  # pyrefly: ignore[assert-type]
+    assert_type(v, Q[Mass, np.ndarray])  # pyrefly: ignore[assert-type]  # ty: ignore[type-assertion-failure]
 
 
 @typechecked

--- a/encomp/tests/test_units.py
+++ b/encomp/tests/test_units.py
@@ -442,7 +442,7 @@ def test_type_eq() -> None:
     # the isinstance check is statically redundant (q is always a Quantity),
     # but the narrowing it produces lets the else branch exercise assert_never
     if isinstance(q, Q):  # pyright: ignore[reportUnnecessaryIsInstance]
-        assert_type(q, Q[Length, float])  # pyrefly: ignore[assert-type]
+        assert_type(q, Q[Length, float])  # pyrefly: ignore[assert-type]  # ty: ignore[type-assertion-failure]
     else:
         assert_never(q)
 

--- a/encomp/units.py
+++ b/encomp/units.py
@@ -877,7 +877,7 @@ class Quantity(
                 raise ValueError(f"Only 1-dimensional NumPy arrays can be used as magnitude, got shape {val.shape}")
             return cast("MT", Quantity._cast_array_float(val))
         elif isinstance(val, (pl.Series, pl.Expr)):
-            return val
+            return cast("MT", val)
         elif hasattr(val, "is_Atom"):
             # implicit way of checking if the value is a sympy symbol without having to import SymPy
             # (must come before the numbers.Real check: sympy Float/Integer register as Real,
@@ -944,7 +944,7 @@ class Quantity(
 
         return self._call_subclass(copy.deepcopy(self._magnitude, memo), copy.deepcopy(self._units, memo))
 
-    def __reduce__(  # pyright: ignore[reportIncompatibleMethodOverride]  # pyrefly: ignore[bad-override]
+    def __reduce__(  # pyright: ignore[reportIncompatibleMethodOverride]  # pyrefly: ignore[bad-override]  # ty: ignore[invalid-method-override]
         self,
     ) -> tuple[object, tuple[object, str, type[Dimensionality] | None]]:
         dim = self.dt if _is_pickle_global(self.dt) else None
@@ -1867,10 +1867,11 @@ class Quantity(
     @classmethod
     def _pydantic_build_quantity(cls, qty: Any) -> Quantity[Any, Any]:  # noqa: ANN401
         if isinstance(qty, dict) and "value" in qty and "magnitude_type" in qty:
-            val = cast(Any, qty["value"])
-            magnitude_type = cast(str, qty["magnitude_type"])
+            qty_dict = cast("dict[str, Any]", qty)
+            val = qty_dict["value"]
+            magnitude_type = cast(str, qty_dict["magnitude_type"])
             magnitude = cls._pydantic_magnitude_from_payload(val, magnitude_type)
-            unit = cast(str | None, cast("dict[str, Any]", qty).get("unit"))
+            unit = cast(str | None, qty_dict.get("unit"))
             return cast("Quantity[Any, Any]", cls(cast(MT, magnitude), unit=unit))
 
         return cast("Quantity[Any, Any]", qty if isinstance(qty, Quantity) else cls(cast(Any, qty)))
@@ -3697,7 +3698,7 @@ class Quantity(
     ) -> Quantity[Any, Any]:
         ret = cast("Quantity[DT, Any]", self._pint_super.__getitem__(index))
 
-        magnitude_type = cast("type[Any]", type(ret.m))
+        magnitude_type = cast("type[Any]", type(ret.m))  # ty: ignore[redundant-cast]
         subcls = self._get_dimensional_subclass(self.dt, self._get_magnitude_type_safe(magnitude_type))
         instance = cast(Any, subcls)(ret.m, ret.u)
 

--- a/encomp/units.py
+++ b/encomp/units.py
@@ -736,7 +736,7 @@ class Quantity(
             "type[Quantity[DT, MT]]",
             type(
                 f"Quantity[{dim_name}, {mt_name}]",
-                (DimensionalQuantity,),
+                (DimensionalQuantity,),  # ty: ignore[unsupported-dynamic-base]
                 {
                     "_magnitude_type": mt,
                     "__class__": DimensionalQuantity,
@@ -1257,10 +1257,10 @@ class Quantity(
 
             # special case for temperature difference
             if cls._is_temperature_difference_unit(valid_unit):
-                subcls = cls._get_dimensional_subclass(TemperatureDifference, type(valid_magnitude))
+                subcls = cls._get_dimensional_subclass(TemperatureDifference, type(valid_magnitude))  # ty: ignore[invalid-argument-type]
             else:
                 dim = Dimensionality.get_dimensionality(valid_unit.dimensionality)
-                subcls = cls._get_dimensional_subclass(dim, type(valid_magnitude))
+                subcls = cls._get_dimensional_subclass(dim, type(valid_magnitude))  # ty: ignore[invalid-argument-type]
 
             return subcls(
                 valid_magnitude,
@@ -1523,7 +1523,7 @@ class Quantity(
         # convert integer arrays to float(64) (creating a copy)
         _m = self._magnitude
         if isinstance(_m, np.ndarray) and issubclass(_m.dtype.type, numbers.Integral):
-            self._magnitude = cast("MT", _m.astype(np.float64))
+            self._magnitude = cast("MT", _m.astype(np.float64))  # ty: ignore[no-matching-overload]
 
         try:
             self._pint_super.ito(valid_unit)
@@ -1538,7 +1538,7 @@ class Quantity(
 
     # check() intentionally accepts a wider set of dimension arguments than
     # pint's PlainQuantity.check, so the override signature is incompatible
-    def check(  # pyright: ignore[reportIncompatibleMethodOverride]  # pyrefly: ignore[bad-override]
+    def check(  # pyright: ignore[reportIncompatibleMethodOverride]  # pyrefly: ignore[bad-override]  # ty: ignore[invalid-method-override]
         self,
         dimension: Quantity[Any, Any] | UnitsContainer | Unit[DT_] | Unit | str | Dimensionality | type[Dimensionality],
     ) -> bool:
@@ -2102,7 +2102,7 @@ class Quantity(
         if dim == TemperatureDifference:
             unit = self._as_temperature_difference_unit(unit)
 
-        subcls = self._get_dimensional_subclass(dim, type(self.m))
+        subcls = self._get_dimensional_subclass(dim, type(self.m))  # ty: ignore[invalid-argument-type]
         return cast("Quantity[DT_, MT]", subcls(self.m, unit))
 
     def unknown(self) -> Quantity[UnknownDimensionality, MT]:
@@ -2234,7 +2234,7 @@ class Quantity(
             other_is_temp_or_diff_temp = other._dimensionality_type in (Temperature, TemperatureDifference)
 
             if self_is_temp_or_diff_temp and other_is_temp_or_diff_temp:
-                return self._temperature_difference_add_sub(other, "add")
+                return self._temperature_difference_add_sub(other, "add")  # ty: ignore[invalid-argument-type]
 
             raise e
 
@@ -2291,7 +2291,7 @@ class Quantity(
             # only Temperature - TemperatureDifference is meaningful here; the
             # reverse (ΔT - T) is not a temperature and stays an error
             if self.dt == Temperature and other._dimensionality_type == TemperatureDifference:
-                return self._temperature_difference_add_sub(other, "sub")
+                return self._temperature_difference_add_sub(other, "sub")  # ty: ignore[invalid-argument-type]
 
             raise e
 
@@ -2299,7 +2299,7 @@ class Quantity(
 
         if isinstance(other, Quantity) and self.dt == Temperature and other._dimensionality_type == Temperature:
             _mt = type(ret.m)
-            subcls = self._get_dimensional_subclass(TemperatureDifference, _mt)
+            subcls = self._get_dimensional_subclass(TemperatureDifference, _mt)  # ty: ignore[invalid-argument-type]
             return subcls(ret.m, ret.u)
 
         return self._call_subclass(ret.m, ret.u)
@@ -2360,7 +2360,7 @@ class Quantity(
     def __eq__(self: Quantity[DT, pl.Expr], other: Quantity[DT, float]) -> pl.Expr: ...
     # for vector magnitudes __eq__ returns an array/Series/Expr of element-wise
     # results, intentionally widening object.__eq__'s bool return (as numpy does)
-    def __eq__(self, other: object) -> bool | Numpy1DBoolArray | pl.Series | pl.Expr:  # pyright: ignore[reportIncompatibleMethodOverride]
+    def __eq__(self, other: object) -> bool | Numpy1DBoolArray | pl.Series | pl.Expr:  # pyright: ignore[reportIncompatibleMethodOverride]  # ty: ignore[invalid-method-override]
         if not isinstance(other, (Quantity, float, int)):
             return bool(self._pint_super.__eq__(other))
 
@@ -2378,7 +2378,7 @@ class Quantity(
 
         m = self.m
         other_m = cast(float | Numpy1DArray | pl.Series | pl.Expr, cast(Any, other).to(self.u).m)
-        self._check_comparable_magnitudes(m, other_m)
+        self._check_comparable_magnitudes(m, other_m)  # ty: ignore[invalid-argument-type]
 
         if isinstance(m, (float, int, np.ndarray)) and isinstance(other_m, (float, int, np.ndarray)):
             ret = _is_close(cast(Any, m), cast(Any, other_m), self.rtol, self.atol)
@@ -2448,7 +2448,7 @@ class Quantity(
     def __ne__(self: Quantity[DT, pl.Expr], other: Quantity[DT, float]) -> pl.Expr: ...
     # for vector magnitudes __ne__ returns an array/Series/Expr of element-wise
     # results, intentionally widening object.__ne__'s bool return (as numpy does)
-    def __ne__(self, other: object) -> bool | Numpy1DBoolArray | pl.Series | pl.Expr:  # pyright: ignore[reportIncompatibleMethodOverride]
+    def __ne__(self, other: object) -> bool | Numpy1DBoolArray | pl.Series | pl.Expr:  # pyright: ignore[reportIncompatibleMethodOverride]  # ty: ignore[invalid-method-override]
         if not isinstance(other, (Quantity, float, int)):
             return bool(self._pint_super.__ne__(other))
 
@@ -2464,7 +2464,7 @@ class Quantity(
 
         m = self.m
         other_m = cast(float | Numpy1DArray | pl.Series | pl.Expr, cast(Any, other).to(self.u).m)
-        self._check_comparable_magnitudes(m, other_m)
+        self._check_comparable_magnitudes(m, other_m)  # ty: ignore[invalid-argument-type]
 
         if isinstance(m, (float, int, np.ndarray)) and isinstance(other_m, (float, int, np.ndarray)):
             ret = ~_is_close(cast(Any, m), cast(Any, other_m), self.rtol, self.atol)
@@ -2522,7 +2522,7 @@ class Quantity(
             raise DimensionalityComparisonError(f"Cannot compare {self} with {other}") from e
 
         if isinstance(other, Quantity):
-            self._check_comparable_magnitudes(self.m, other.m)
+            self._check_comparable_magnitudes(self.m, other.m)  # ty: ignore[invalid-argument-type]
 
         # only the STRICT pint operator is ever evaluated; a non-strict result is derived
         # from it below. Using pint's raw >= / <= would poison the derivation for NaN:
@@ -2578,7 +2578,7 @@ class Quantity(
     def __gt__(self: Quantity[DT, pl.Expr], other: Quantity[DT, float]) -> pl.Expr: ...
     @overload
     def __gt__(self: Quantity[DT, float], other: Quantity[DT, pl.Expr]) -> pl.Expr: ...
-    def __gt__(self, other: Quantity[DT, Any] | float) -> bool | Numpy1DBoolArray | pl.Series | pl.Expr:
+    def __gt__(self, other: Quantity[DT, Any] | float) -> bool | Numpy1DBoolArray | pl.Series | pl.Expr:  # ty: ignore[invalid-method-override]
         return self._ordering_comparison(other, "__gt__")
 
     @overload
@@ -2605,7 +2605,7 @@ class Quantity(
     def __ge__(self: Quantity[DT, pl.Expr], other: Quantity[DT, float]) -> pl.Expr: ...
     @overload
     def __ge__(self: Quantity[DT, float], other: Quantity[DT, pl.Expr]) -> pl.Expr: ...
-    def __ge__(self, other: Quantity[DT, Any] | float) -> bool | Numpy1DBoolArray | pl.Series | pl.Expr:
+    def __ge__(self, other: Quantity[DT, Any] | float) -> bool | Numpy1DBoolArray | pl.Series | pl.Expr:  # ty: ignore[invalid-method-override]
         return self._ordering_comparison(other, "__ge__")
 
     @overload
@@ -2632,7 +2632,7 @@ class Quantity(
     def __lt__(self: Quantity[DT, pl.Expr], other: Quantity[DT, float]) -> pl.Expr: ...
     @overload
     def __lt__(self: Quantity[DT, float], other: Quantity[DT, pl.Expr]) -> pl.Expr: ...
-    def __lt__(self, other: Quantity[DT, Any] | float) -> bool | Numpy1DBoolArray | pl.Series | pl.Expr:
+    def __lt__(self, other: Quantity[DT, Any] | float) -> bool | Numpy1DBoolArray | pl.Series | pl.Expr:  # ty: ignore[invalid-method-override]
         return self._ordering_comparison(other, "__lt__")
 
     @overload
@@ -2659,7 +2659,7 @@ class Quantity(
     def __le__(self: Quantity[DT, pl.Expr], other: Quantity[DT, float]) -> pl.Expr: ...
     @overload
     def __le__(self: Quantity[DT, float], other: Quantity[DT, pl.Expr]) -> pl.Expr: ...
-    def __le__(self, other: Quantity[DT, Any] | float) -> bool | Numpy1DBoolArray | pl.Series | pl.Expr:
+    def __le__(self, other: Quantity[DT, Any] | float) -> bool | Numpy1DBoolArray | pl.Series | pl.Expr:  # ty: ignore[invalid-method-override]
         return self._ordering_comparison(other, "__le__")
 
     @overload
@@ -3693,13 +3693,13 @@ class Quantity(
     def __getitem__(
         self: Quantity[DT, Numpy1DArray], index: Numpy1DBoolArray | Numpy1DIntArray | Sequence[int]
     ) -> Quantity[DT, Numpy1DArray]: ...
-    def __getitem__(
+    def __getitem__(  # ty: ignore[invalid-method-override]
         self, index: int | slice | Numpy1DBoolArray | Numpy1DIntArray | Sequence[int]
     ) -> Quantity[Any, Any]:
         ret = cast("Quantity[DT, Any]", self._pint_super.__getitem__(index))
 
         magnitude_type = cast("type[Any]", type(ret.m))  # ty: ignore[redundant-cast]
-        subcls = self._get_dimensional_subclass(self.dt, self._get_magnitude_type_safe(magnitude_type))
+        subcls = self._get_dimensional_subclass(self.dt, self._get_magnitude_type_safe(magnitude_type))  # ty: ignore[invalid-argument-type]
         instance = cast(Any, subcls)(ret.m, ret.u)
 
         return cast("Quantity[Any, Any]", instance)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -241,6 +241,11 @@ include = ["encomp"]
 [tool.ty.environment]
 python-version = "3.13"
 
+[tool.ty.terminal]
+# any ty warning (e.g. a typo'd rule name in an ignore comment) fails `ty check`,
+# matching how the other two checkers are gated; no CLI flag needed in CI
+error-on-warning = true
+
 [tool.ty.rules]
 # ty's default rule set is already effectively strict; these are the rules that are
 # not error-by-default, elevated here. ty runs as the third checker in CI alongside

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -242,9 +242,13 @@ include = ["encomp"]
 python-version = "3.13"
 
 [tool.ty.rules]
-# ty's default rule set is already effectively strict; these are the rules
-# that are not error-by-default, elevated here so manual `ty check` runs use
-# the intended strictness. ty is intentionally local-only for now.
+# ty's default rule set is already effectively strict; these are the rules that are
+# not error-by-default, elevated here. ty runs as the third checker in CI alongside
+# pyright and pyrefly; where it disagrees with pyright (the primary checker), the
+# code carries a rule-specific `# ty: ignore[...]` comment instead of being changed.
 redundant-cast = "error"
 possibly-missing-attribute = "error"
 unsupported-dynamic-base = "error"
+# match pyright's reportUnnecessaryTypeIgnoreComment and pyrefly's unused-ignore:
+# a `ty: ignore` that no longer suppresses anything must fail, not linger
+unused-ignore-comment = "error"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "encomp"
-version = "1.7.1"
+version = "1.7.2"
 description = "General-purpose library for engineering computations"
 authors = [{ name = "William Laurén", email = "lauren.william.a@gmail.com" }]
 requires-python = ">=3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -514,7 +514,7 @@ wheels = [
 
 [[package]]
 name = "encomp"
-version = "1.7.1"
+version = "1.7.2"
 source = { editable = "." }
 dependencies = [
     { name = "coolprop" },


### PR DESCRIPTION
## Summary

- resolve the 71 ty diagnostics: ~11 via genuine code improvements, the rest via rule-specific `# ty: ignore[...]` comments where ty disagrees with pyright (the source of truth) and pyrefly — all suppressed lines pass both other checkers unmodified and are exercised at runtime by the test suite
- gate `ty check` in the CI typecheck job; warnings fail too via `[tool.ty.terminal] error-on-warning = true`, and `unused-ignore-comment` is elevated to error so stale suppressions cannot linger
- extend the doc-block tests (`test_docs.py`) and the static-rejection guarantees (`test_static_typing.py`) to ty, twinned with the existing pyright/pyrefly variants
- add `AGENTS.md` documenting the three-checker protocol, executable-docs rule and library invariants, with `CLAUDE.md` redirecting to it
- bump to 1.7.2

## Verification

- pyright: 0 errors, pyrefly: 0 errors, ty: 0 diagnostics (with error-on-warning)
- full pytest suite green locally (785 tests + 217 doc-block checks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)