### PR TITLE
release: encomp 1.9.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "encomp"
-version = "1.8.0"
+version = "1.9.0"
 description = "General-purpose library for engineering computations"
 authors = [{ name = "William Laurén", email = "lauren.william.a@gmail.com" }]
 requires-python = ">=3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -514,7 +514,7 @@ wheels = [
 
 [[package]]
 name = "encomp"
-version = "1.8.0"
+version = "1.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },


### PR DESCRIPTION
## Summary

Release encomp 1.9.0 after #21:

- removes the Python CoolProp runtime package and uses one bundled native CoolProp implementation
- simplifies scalar and Polars fluid-property evaluation around that single backend
- adds independent test-only CoolProp parity coverage, packaging checks, and performance benchmarks
- updates the README and documentation for the simplified API

## Validation

- implementation CI: https://github.com/wlaur/encomp/actions/runs/29842004810
- this PR changes only the version in `pyproject.toml` and `uv.lock`

After this PR is green and merged, tag `v1.9.0` to publish PyPI and create the GitHub release.