### PR TITLE
fix: resolve review findings and release 1.9.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ pip install encomp
 
 `encomp` ships as a single per-platform wheel containing its dual-purpose native Rust artifact and one bundled CoolProp shared library, so supported platforms have nothing to build and do not install the Python `CoolProp` package. Wheels are provided for Windows (x86_64), Linux (x86_64 and arm64), and macOS (Apple Silicon only). PyPI does not publish an sdist; unsupported platforms, including Intel Macs, need a build from the git repository; see [Tests](#tests).
 
-On the macOS arm64 wheel measured for the native-only change, the resolver's combined wheel download falls from 19.61 MB (`encomp` plus the separate Python CoolProp wheel) to 9.08 MB for `encomp` alone, a 53.7% reduction. The `encomp` artifact itself grows by about 35 KB for the scalar bridge and bundled license; removing the separate 10.57 MB wheel is where the installation-size saving comes from.
+On macOS arm64, the native-only package reduces the resolver's combined wheel download from about 19.6 MB (`encomp` plus the separate Python CoolProp wheel) to about 9 MB for `encomp` alone—roughly a 54% reduction. The `encomp` artifact itself grows only slightly for the scalar bridge and bundled license; removing the separate CoolProp wheel is where the installation-size saving comes from.
 
 ## The `Quantity` class
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -599,7 +599,7 @@ Fluid("toluene", T=Q(25, "°C"), P=Q(2, "bar"))
 state: Any = {"P": Q(1, "bar"), "Q": Q(2)}
 
 invalid_inputs = Fluid("water", **state)
-# <Fluid "water", P=100 kPa, T=nan °C, D=nan kg/m³, V=nan cP>
+# <Fluid "water", P=nan kPa, T=nan °C, D=nan kg/m³, V=nan cP>
 
 # derived properties are nan (and may log a warning about the invalid state)
 temperature = invalid_inputs.T  # nan °C
@@ -904,7 +904,7 @@ x, y, z = sp.symbols("x, y, z")  # pyright: ignore[reportUnknownMemberType]
 
 # output is a Quantity with a symbolic magnitude
 Q(1) * x  # 1.0*x dimensionless
-Q(10, "%") * x  # 10.0*x percent
+Q(10, "%") * x  # 10.0*x %
 
 # output is a sympy object
 x * Q(1)  # 1.0*x

--- a/encomp/_polars_dtype.py
+++ b/encomp/_polars_dtype.py
@@ -28,9 +28,21 @@ def canonical_unit_string(unit: str | Unit[Any]) -> str:
     is an on-disk, cross-process contract. It normalizes spelling (``"m^3"`` and
     ``"m³"``), not physical equivalence (``"Pa"`` and ``"N/m²"`` remain distinct).
     """
-    from .units import Unit
+    from tokenize import TokenError
 
-    parsed = Unit(unit) if isinstance(unit, str) else unit
+    from pint.errors import UndefinedUnitError
+
+    from .units import Quantity, Unit
+
+    if isinstance(unit, str):
+        try:
+            parsed = Unit(Quantity.correct_unit(unit))
+        except (AssertionError, TokenError) as e:
+            # Pint's tokenizer uses internal assertions for a few malformed strings.
+            # Do not leak that implementation detail from a public dtype constructor.
+            raise UndefinedUnitError(unit) from e
+    else:
+        parsed = unit
     return format(parsed, _CANONICAL_UNIT_FORMAT)
 
 

--- a/encomp/coolprop/README.md
+++ b/encomp/coolprop/README.md
@@ -67,9 +67,11 @@ configurations averages 29.37 us/configuration. Reproduce with
 `scripts/benchmark_coolprop.py`.
 
 The matching macOS arm64 package check reduces the combined wheel download from
-19.61 MB (`encomp` plus Python CoolProp) to 9.08 MB for `encomp` alone (-53.7%).
-The encomp wheel itself is about 35 KB larger because the old Python binding was
-a separate distribution; removing that 10.57 MB wheel produces the net saving.
+about 19.6 MB (`encomp` plus Python CoolProp) to about 9 MB for `encomp` alone
+(roughly -54%). The encomp wheel itself is only slightly larger because the old
+Python binding was a separate distribution; removing that separate wheel produces
+the net saving. The bundled CoolProp distribution terms are shipped as
+`encomp/coolprop/LICENSE.CoolProp`.
 
 ## Design
 

--- a/encomp/coolprop/__init__.py
+++ b/encomp/coolprop/__init__.py
@@ -658,8 +658,14 @@ def resolve_fluid_spec(
     else:
         backend, fluids, fractions = _native().resolve_fluid_name(name)
         # The native parser validates + returns fractions only when the name carries
-        # them; one remaining species is an incompressible concentration (absolute basis).
-        is_concentration = fractions is not None and "&" not in fluids
+        # them. Only INCOMP uses a one-species absolute concentration; every other
+        # bracket value is a mole-fraction vector and must therefore sum to one.
+        is_concentration = fractions is not None and backend.upper() == "INCOMP" and "&" not in fluids
+        if fractions is None and "&" in fluids:
+            raise ValueError(
+                f"mixture {fluids!r} requires mole fractions; include them in the name "
+                "(e.g. 'HEOS::CO2[0.5]&O2[0.5]') or pass composition=."
+            )
     # mixture mole fractions must sum to 1; a concentration is absolute and passes through
     if fractions is not None and not is_concentration:
         total = sum(fractions)

--- a/encomp/fluids.py
+++ b/encomp/fluids.py
@@ -24,6 +24,7 @@ from .coolprop import (
     _fluid_scalar,  # pyright: ignore[reportPrivateUsage]
     _humid_air_scalar,  # pyright: ignore[reportPrivateUsage]
     _native,  # pyright: ignore[reportPrivateUsage]
+    _resolve_pair,  # pyright: ignore[reportPrivateUsage]
     is_fluid_param,
     is_humid_air_param,
     resolve_fluid_spec,
@@ -689,10 +690,12 @@ class CoolPropFluid(ABC, Generic[MT]):  # noqa: UP046
             _LOGGER.warning(f'CoolProp could not calculate "{prop}" for fluid "{self.name}", output is NaN: {msg}')
 
     def check_exception(self, prop: CProperty, e: ValueError) -> None:
-        """Re-raise ``e``, or return so the caller can yield ``NaN`` for ``prop``.
+        """Classify an evaluation error before the caller yields ``NaN`` for ``prop``.
 
         CoolProp signals both "out of range" and "not implemented" with ``ValueError``;
-        those cases warn (or stay silent) and produce ``NaN``. Anything else re-raises.
+        those cases warn (or stay silent) and produce ``NaN``. Fluid initialization
+        errors are rewritten and re-raised; other native evaluation failures warn and
+        produce ``NaN`` because CoolProp does not expose a stable error taxonomy.
         """
 
         msg = str(e)
@@ -794,6 +797,13 @@ class CoolPropFluid(ABC, Generic[MT]):  # noqa: UP046
         # input. Mask here so scalar and batch/plugin paths agree.
         if not all(np.isfinite(value) for _, value in points):
             return np.nan
+
+        # Pair resolution is request validation, not a failed state evaluation. Do it
+        # outside the try/NaN normalization so all magnitude containers reject an
+        # unsupported pair consistently.
+        if self.BACKEND_KIND != "humid_air":
+            (name1, _), (name2, _) = points
+            _resolve_pair(name1, name2)
 
         try:
             if self.BACKEND_KIND == "humid_air":
@@ -1094,7 +1104,7 @@ class Fluid(CoolPropFluid[MT]):
         else:
             self.name = name
 
-        _validate_fluid_name(self.name)
+        _validate_fluid_name(self.name, self._composition)
 
         points = self._build_points(kwargs)
 

--- a/encomp/polars.py
+++ b/encomp/polars.py
@@ -354,7 +354,12 @@ class QuantityFrame:
             if dtype.unit == declaration.unit:
                 continue
 
-            source = Quantity(pl.col(declaration.name).ext.storage(), dtype.unit).asdim(declaration.dimensionality)
+            # Persisted units are data, not an instruction to reinterpret physical
+            # meaning. Ordinary compatible-unit conversions are allowed, while `.to`
+            # deliberately refuses absolute-temperature ↔ temperature-difference
+            # crossings. `asdim` remains available only at the explicit declaration
+            # boundary (`unit(..., asdim=...)`).
+            source = Quantity(pl.col(declaration.name).ext.storage(), dtype.unit)
             converted = source.to(declaration.unit).m.alias(declaration.name)
             storage = lf.select(converted).collect_schema()[declaration.name]
             conversions.append(converted.ext.to(UnitDType(declaration.unit, storage=storage)).alias(declaration.name))

--- a/encomp/tests/test_coolprop_plugin.py
+++ b/encomp/tests/test_coolprop_plugin.py
@@ -282,10 +282,19 @@ def test_null_inputs_become_null() -> None:
     # NULL input cells (not just out-of-range values) yield NULL outputs, matching the
     # eager numpy/NaN path -- the lazy plugin must not hard-error on the first null
     # (nulls are ubiquitous in real frames: joins, sensor dropouts)
-    df = pl.DataFrame({"P": [50e5, None, 60e5], "T": [400.0, 450.0, None]})
-    rho = df.select(rho=cp.water("DMASS", "P", "T"))["rho"]
+    df = pl.DataFrame({"P": [50e5, None, float("nan"), 60e5], "T": [400.0, 450.0, 450.0, None]})
+    out = df.select(
+        rho=cp.water("DMASS", "P", "T"),
+        quality=cp.water("Q", "P", "T"),
+        critical_temperature=cp.water("TCRIT", "P", "T"),
+    )
+    rho = out["rho"]
     assert rho[0] is not None and np.isfinite(rho[0])
-    assert rho[1] is None and rho[2] is None  # null P, then null T -> null
+    assert rho[1:].null_count() == 3
+    # IF97 can return finite state-independent/trivial values for a NaN input. The
+    # kernel must mask from the inputs rather than relying on the flash to fail.
+    assert out["quality"][1:].null_count() == 3
+    assert out["critical_temperature"][1:].null_count() == 3
     # humid air path handles nulls the same way
     df2 = pl.DataFrame({"P": [101325.0, None], "T": [293.15, 300.0], "R": [0.5, 0.5]})
     w = df2.select(w=cp.humid_air("W", "P", "T", "R"))["w"]
@@ -494,6 +503,36 @@ def test_fluid_composition_validation_matches_fluids() -> None:
         cp.fluid("DMASS", "P", "T", name="HEOS", composition={"Water": 1.0})
     with pytest.raises(ValueError, match="non-negative"):  # invalid fraction
         cp.fluid("DMASS", "P", "T", name="HEOS", composition={"CO2": -0.7, "O2": 0.3})
+    with pytest.raises(ValueError, match="sum to 1"):
+        cp.fluid("DMASS", "P", "T", name="HEOS::CO2[0.5]")
+    # A unit single-species vector is accepted and is equivalent to the pure fluid.
+    pure = pl.DataFrame({"P": [5e6], "T": [300.0]}).select(
+        cp.fluid("DMASS", "P", "T", name="HEOS::CO2[1.0]").alias("D")
+    )
+    reference = pl.DataFrame({"P": [5e6], "T": [300.0]}).select(
+        cp.fluid("DMASS", "P", "T", name="HEOS::CO2").alias("D")
+    )
+    assert pure["D"][0] == pytest.approx(reference["D"][0])
+
+
+@pytest.mark.parametrize("dtype", [pl.Int8, pl.Int16, pl.UInt8, pl.UInt16])
+def test_small_integer_inputs_do_not_panic(dtype: type[pl.DataType]) -> None:
+    fluid = pl.DataFrame({"P": pl.Series([100, 120], dtype=dtype), "T": [400.0, 420.0]})
+    density = fluid.select(cp.water("DMASS", "P", "T"))["DMASS"]
+    assert density.len() == 2
+    assert density.dtype == pl.Float64
+
+    humid = pl.DataFrame({"P": [101325.0, 101325.0], "T": [300.0, 305.0], "R": pl.Series([0, 1], dtype=dtype)})
+    humidity = humid.select(cp.humid_air("W", "P", "T", "R"))["W"]
+    assert humidity.len() == 2
+    assert humidity.dtype == pl.Float64
+
+
+@pytest.mark.parametrize("values", [[True, False], ["100000", "120000"], [[100000], [120000]]])
+def test_nonnumeric_inputs_are_rejected(values: list[object]) -> None:
+    df = pl.DataFrame({"P": values, "T": [400.0, 420.0]})
+    with pytest.raises(Exception, match="must be a numeric column"):
+        df.select(cp.water("DMASS", "P", "T"))
 
 
 def test_composition_non_unit_sum_raises() -> None:

--- a/encomp/tests/test_docs.py
+++ b/encomp/tests/test_docs.py
@@ -50,14 +50,23 @@ import re
 import shutil
 import subprocess
 import sys
+import tomllib
 from pathlib import Path
+from typing import cast
 
 import pytest
 
 
 def _repo_root() -> Path | None:
     for parent in Path(__file__).resolve().parents:
-        if (parent / "pyproject.toml").is_file() and (parent / "docs").is_dir():
+        pyproject = parent / "pyproject.toml"
+        if not pyproject.is_file() or not (parent / "docs").is_dir():
+            continue
+        try:
+            project = tomllib.loads(pyproject.read_text()).get("project", {})
+        except (OSError, tomllib.TOMLDecodeError):
+            continue
+        if isinstance(project, dict) and cast("dict[str, object]", project).get("name") == "encomp":
             return parent
     return None
 
@@ -129,6 +138,18 @@ _CODES = [code for _, code in _CASES]
 def test_docs_have_blocks() -> None:
     # tripwire: if extraction silently finds nothing, the checks below vacuously pass
     assert len(_CASES) > 20, f"expected many doc code blocks, found {len(_CASES)}"
+
+
+def test_repo_root_rejects_unrelated_user_project(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    project = tmp_path / "user-project"
+    installed_test = project / ".venv" / "lib" / "python3.13" / "site-packages" / "encomp" / "tests" / "test_docs.py"
+    installed_test.parent.mkdir(parents=True)
+    (project / "docs").mkdir()
+    (project / "pyproject.toml").write_text('[project]\nname = "user-project"\n')
+
+    module = sys.modules[__name__]
+    monkeypatch.setattr(module, "__file__", str(installed_test))
+    assert _repo_root() is None
 
 
 def test_doc_block_discovery_covers_public_docs() -> None:

--- a/encomp/tests/test_fluids.py
+++ b/encomp/tests/test_fluids.py
@@ -257,6 +257,19 @@ def test_incorrect_inputs() -> None:
     with pytest.raises(ValueError, match="could not be initialized"):
         Fluid("this fluid name does not exist", P=Q(2, "bar"), T=Q(25, "°C"))
 
+    with pytest.raises(ValueError, match="requires mole fractions"):
+        Fluid("HEOS::CO2&O2", P=Q(50.0, "bar"), T=Q(300.0, "K"))
+
+    with pytest.raises(ValueError, match="sum to 1"):
+        Fluid("HEOS::CO2[0.5]", P=Q(50.0, "bar"), T=Q(300.0, "K"))
+
+    pure = Fluid("HEOS::CO2", P=Q(50.0, "bar"), T=Q(300.0, "K")).D
+    unit_fraction = Fluid("HEOS::CO2[1.0]", P=Q(50.0, "bar"), T=Q(300.0, "K")).D
+    assert unit_fraction.m == approx(pure.m)
+
+    with pytest.raises(ValueError, match="unsupported CoolProp input pair"):
+        _ = Water(H=Q(1000.0, "kJ/kg"), Q=Q(0.5)).T
+
     p = np.zeros((5, 5))
     t = np.zeros(5)
 

--- a/encomp/tests/test_native_coolprop.py
+++ b/encomp/tests/test_native_coolprop.py
@@ -103,6 +103,8 @@ def test_native_name_parsing_and_validation() -> None:
     assert native.resolve_fluid_name("HEOS::CO2[0.5]&O2[0.5]") == ("HEOS", "CO2&O2", [0.5, 0.5])
     assert native.resolve_fluid_name("INCOMP::MEG[0.5]") == ("INCOMP", "MEG", [0.5])
     assert native.resolve_fluid_name("INCOMP::EG-20%") == ("INCOMP", "EG", [0.2])
+    with raises(ValueError, match="between 0% and 100%"):
+        native.resolve_fluid_name("INCOMP::EG-120%")
 
     native.validate_fluid("IF97", "Water")
     native.validate_fluid("HEOS", "CO2&O2", [0.5, 0.5])
@@ -171,6 +173,18 @@ def test_thread_local_cache_eviction_and_destruction() -> None:
     assert native.scalar_cache_info()[0] == 0
     _, freed_after = native.handle_counts()
     assert freed_after - freed_before >= len(fluids)
+
+
+def test_failed_scalar_flash_keeps_cached_state() -> None:
+    native = cp._native()
+    native.clear_scalar_cache()
+
+    assert math.isnan(Water(P=Q(-1.0, "Pa"), T=Q(300.0, "K")).D.m)
+    assert math.isfinite(Water(P=Q(1e5, "Pa"), T=Q(300.0, "K")).D.m)
+
+    size, _capacity, hits, misses, _evictions = native.scalar_cache_info()
+    assert size == 1
+    assert (hits, misses) == (1, 1)
 
 
 def test_concurrent_scalar_success_and_failure_are_isolated() -> None:

--- a/encomp/tests/test_polars.py
+++ b/encomp/tests/test_polars.py
@@ -115,8 +115,5 @@ def test_datetimes() -> None:
         }
     )
 
-    qty = Q(df["time"])
-    assert qty.m[0] == datetime(2025, 1, 1)
-
-    with raises(TypeError):
-        qty[0]
+    with raises(TypeError, match="float or integer dtype"):
+        Q(df["time"])

--- a/encomp/tests/test_polars_units.py
+++ b/encomp/tests/test_polars_units.py
@@ -13,6 +13,7 @@ from typing import Any, assert_type, cast
 
 import polars as pl
 import pytest
+from pint.errors import UndefinedUnitError
 from polars.exceptions import InvalidOperationError, SchemaError
 from pytest import raises
 
@@ -28,7 +29,16 @@ from ..polars import (
 )
 from ..units import Quantity as Q
 from ..units import Unit
-from ..utypes import Density, Power, Pressure, Temperature, UnknownDimensionality, Velocity, VolumeFlow
+from ..utypes import (
+    Density,
+    Power,
+    Pressure,
+    Temperature,
+    TemperatureDifference,
+    UnknownDimensionality,
+    Velocity,
+    VolumeFlow,
+)
 
 
 def _sensor_df() -> pl.DataFrame:
@@ -94,13 +104,32 @@ def test_quantity_frame_validates_and_normalizes_stored_units() -> None:
     assert units_of(sensors.lf) == {"pressure": Unit("bar"), "Volume flow": Unit("m³/h")}
     assert sensors.lf.select(sensors.pressure.m).collect().to_series().to_list() == [1.0, 2.0]
 
-    with raises(Exception, match=r"[Dd]imension"):
+    with raises(Exception, match=r"Cannot convert"):
         Sensors(
             with_units(
                 pl.DataFrame({"pressure": [1.0], "Volume flow": [1.0]}),
                 {"pressure": "m", "Volume flow": "m³/h"},
             )
         )
+
+
+def test_quantity_frame_refuses_temperature_reinterpretation() -> None:
+    class Absolute(QuantityFrame):
+        value = unit("degC")
+
+    class Difference(QuantityFrame):
+        value = unit("delta_degC")
+
+    absolute = with_units(pl.DataFrame({"value": [25.0]}), {"value": "degC"})
+    difference = with_units(pl.DataFrame({"value": [5.0]}), {"value": "delta_degC"})
+
+    with raises(Exception, match=r"[Tt]emperature"):
+        Difference(absolute)
+    with raises(Exception, match=r"[Tt]emperature"):
+        Absolute(difference)
+
+    assert_type(Absolute.value, Column[Temperature])
+    assert_type(Difference.value, Column[TemperatureDifference])
 
 
 def test_quantity_frame_boundaries_are_explicit() -> None:
@@ -144,10 +173,14 @@ def test_unit_dtype_normalization() -> None:
     # Canonicalization normalizes syntax, not physical equivalence. This conservative
     # identity is what lets the Rust plugin compare metadata without embedding Pint.
     assert UnitDType("Pa") != UnitDType("N/m²")
+    assert UnitDType("Nm3/h") == UnitDType("Nm³/h")
+    assert UnitDType("-").unit == Unit("")
 
     # an unknown unit fails at dtype construction, not at attach or write time
     with raises(Exception, match="asdfgh"):
         UnitDType("asdfgh")
+    with raises(UndefinedUnitError):
+        UnitDType("(")
 
 
 def test_unit_dtype_metadata_ignores_display_format() -> None:

--- a/encomp/tests/test_resolve_fluid_spec.py
+++ b/encomp/tests/test_resolve_fluid_spec.py
@@ -64,6 +64,17 @@ def test_incompressible_concentration_is_not_normalised() -> None:
     assert fractions == pytest.approx([0.5])
 
 
+def test_single_species_fraction_is_only_a_concentration_for_incomp() -> None:
+    assert cp.resolve_fluid_spec("HEOS::CO2[1.0]") == ("HEOS", "CO2", [1.0])
+    with pytest.raises(ValueError, match="sum to 1"):
+        cp.resolve_fluid_spec("HEOS::CO2[0.5]")
+
+
+def test_mixture_without_fractions_is_rejected() -> None:
+    with pytest.raises(ValueError, match="requires mole fractions"):
+        cp.resolve_fluid_spec("HEOS::CO2&O2")
+
+
 @pytest.mark.parametrize(
     ("name", "composition", "match"),
     [

--- a/encomp/tests/test_units.py
+++ b/encomp/tests/test_units.py
@@ -1835,6 +1835,9 @@ def test_astype() -> None:
     with pytest.raises(TypeError, match="scalar"):
         Q([1, 2, 3]).astype("float")
 
+    with pytest.raises(TypeError, match=r"pl\.Expr.*pl\.Series"):
+        Q(pl.lit(1.5), "m").astype(pl.Series)
+
 
 def test_single_element_array_magnitude() -> None:
     s1_list = [1.0]
@@ -2171,6 +2174,63 @@ def test_bool_magnitude_is_rejected() -> None:
     # comparing against a bool still works (the bool never becomes a magnitude)
     assert Q(1.0) == True  # noqa: E712
     assert Q(0.5) != True  # noqa: E712
+
+
+def test_polars_series_magnitude_validation() -> None:
+    with pytest.raises(TypeError, match="float or integer dtype"):
+        Q(cast(Any, pl.Series([True, False])), "m")
+    with pytest.raises(TypeError, match="float or integer dtype"):
+        Q(cast(Any, pl.Series(["a", "b"])), "m")
+    with pytest.raises(TypeError, match="float or integer dtype"):
+        Q(cast(Any, pl.Series([[1.0], [2.0]])), "m")
+
+    from ..polars import with_units
+
+    unit_typed = with_units(pl.DataFrame({"x": [1.0, 2.0]}), {"x": "bar"})["x"]
+    with pytest.raises(TypeError, match="unit-typed"):
+        Q(cast(Any, unit_typed), "m")
+
+    integers = Q(pl.Series([1, 2]), "m")
+    assert integers.m.dtype == pl.Float64
+
+    values = Q(pl.Series([1.0, 2.0]), "m")
+    with pytest.raises(TypeError, match="float or integer dtype"):
+        values.m = cast(Any, pl.Series([True, False]))
+
+
+def test_floordiv_is_consistent_across_magnitude_containers() -> None:
+    scalar = Q(1.0, "m") // Q(1.0, "cm")
+    array = Q(np.array([1.0]), "m") // Q(np.array([1.0]), "cm")
+    series = Q(pl.Series([1.0]), "m") // Q(pl.Series([1.0]), "cm")
+    expression = Q(pl.lit(1.0), "m") // Q(pl.lit(1.0), "cm")
+
+    assert scalar.m == 100.0
+    assert array.m.tolist() == [100.0]
+    assert series.m.to_list() == [100.0]
+    assert pl.select(expression.m).item() == 100.0
+
+    negative_infinity = Q(1.0, "m") // Q(float("-inf"), "cm")
+    assert negative_infinity.m == 0.0
+    assert np.signbit(negative_infinity.m)
+
+
+def test_mixed_container_arithmetic_is_rejected() -> None:
+    array = cast(Any, Q(np.array([1.0, 2.0]), "m"))
+    series = cast(Any, Q(pl.Series([1.0, 2.0]), "m"))
+    expression = cast(Any, Q(pl.lit(2.0), "m"))
+    exponent = cast(Any, Q(pl.Series([2.0, 2.0])))
+
+    operations = (
+        lambda: array + series,
+        lambda: array - series,
+        lambda: array * expression,
+        lambda: array / series,
+        lambda: array // series,
+        lambda: array**exponent,
+    )
+    for operation in operations:
+        with pytest.raises(TypeError, match="Cannot combine"):
+            operation()
 
 
 def test_quantity_as_unit_is_rejected() -> None:

--- a/encomp/units.py
+++ b/encomp/units.py
@@ -452,9 +452,9 @@ class Quantity(
 
     ``Quantity`` extends Pint's quantity type with runtime dimensionality subclasses
     (for example ``Quantity[Pressure, float]``) and magnitude containers such as
-    ``float``, numpy arrays, Polars ``Series`` and Polars ``Expr``. Construction
-    validates that the unit's physical dimensions match the requested dimensionality
-    subclass.
+    ``float``, numpy arrays, Polars ``Series`` and Polars ``Expr``. The runtime
+    dimensionality subclass is selected from the unit; explicit semantic
+    reinterpretation is validated by :meth:`asdim`.
 
     Absolute temperature and temperature-difference quantities deliberately remain
     separate dimensionality types even though both have Pint dimension
@@ -626,14 +626,16 @@ class Quantity(
             raise TypeError(f"Invalid magnitude type: {mt} (origin {origin})")
 
     @classmethod
-    def _check_comparable_magnitudes(cls, m: object, other_m: object) -> None:
-        # Mixed containers do not compare elementwise: numpy-vs-polars raises an opaque
+    def _check_comparable_magnitudes(
+        cls, m: object, other_m: object, operation: Literal["compare", "combine"] = "compare"
+    ) -> None:
+        # Mixed containers do not interoperate reliably: numpy-vs-polars raises an opaque
         # ufunc-loop TypeError or dtype error, and pl.Expr silently lifts an ndarray OR a
         # pl.Series into a literal and compares EXACTLY, skipping the (rtol, atol) tolerance
         # every sanctioned path applies -- with a length mismatch surfacing only at collect()
-        # time as a ShapeError pointing into the plan. None of these combinations is in the
-        # typed API (the __eq__/__gt__/... overloads pair a magnitude type with itself or with
-        # a scalar), so reject them here with an actionable message instead
+        # time as a ShapeError pointing into the plan. Arithmetic has the same problem and
+        # can even change behavior after numpy/pint dispatch has been warmed. None of these
+        # combinations is in the typed API, so reject them with an actionable message.
         if cls._is_mixed_container(m, other_m):
             if isinstance(m, pl.Expr) or isinstance(other_m, pl.Expr):
                 hint = (
@@ -644,7 +646,7 @@ class Quantity(
                 hint = 'convert one side first, e.g. with .astype("pl.Series") or .astype("ndarray")'
 
             raise TypeError(
-                f"Cannot compare a Quantity with {cls._describe_magnitude(m)} magnitude to one with "
+                f"Cannot {operation} a Quantity with {cls._describe_magnitude(m)} magnitude with one with "
                 f"{cls._describe_magnitude(other_m)} magnitude; {hint}"
             )
 
@@ -668,6 +670,14 @@ class Quantity(
             return "pl.Expr"
 
         return type(value).__name__
+
+    @staticmethod
+    def _floor_magnitude(value: Any) -> Any:  # noqa: ANN401
+        if isinstance(value, (pl.Series, pl.Expr)):
+            return value.floor()
+        if isinstance(value, np.ndarray):
+            return np.floor(cast("Numpy1DArray", value))
+        return float(np.floor(value))
 
     @staticmethod
     def _get_magnitude_type_from_name(mt_name: MagnitudeTypeName) -> type:
@@ -876,7 +886,18 @@ class Quantity(
             if len(val.shape) != 1:
                 raise ValueError(f"Only 1-dimensional NumPy arrays can be used as magnitude, got shape {val.shape}")
             return cast("MT", Quantity._cast_array_float(val))
-        elif isinstance(val, (pl.Series, pl.Expr)):
+        elif isinstance(val, pl.Series):
+            if val.dtype == pl.Null:
+                return cast("MT", val.cast(pl.Float64))
+            if val.dtype.is_integer():
+                return cast("MT", val.cast(pl.Float64))
+            if not val.dtype.is_float():
+                raise TypeError(
+                    f"Polars Series magnitude must have a float or integer dtype, got {val.dtype!r}. "
+                    "Boolean, non-numeric, nested, and unit-typed Series are not valid magnitudes."
+                )
+            return cast("MT", val)
+        elif isinstance(val, pl.Expr):
             return cast("MT", val)
         elif hasattr(val, "is_Atom"):
             # implicit way of checking if the value is a sympy symbol without having to import SymPy
@@ -2175,6 +2196,10 @@ class Quantity(
             vals = np.array(_m)
             return cast("Quantity[DT, Any]", self.get_subclass(dt, np.ndarray)(vals, u))
         elif magnitude_type is pl.Series:
+            if isinstance(m, pl.Expr):
+                raise TypeError(
+                    "Cannot convert a pl.Expr magnitude to pl.Series; evaluate the expression in a Polars frame first"
+                )
             _m = [m] if not isinstance(m, Iterable) else m
             vals = pl.Series(values=_m)
             return cast("Quantity[DT, Any]", self.get_subclass(dt, pl.Series)(vals, u))
@@ -2196,6 +2221,8 @@ class Quantity(
     @overload
     def __pow__(self, other: Quantity[Dimensionless, MT]) -> Quantity[UnknownDimensionality, MT]: ...
     def __pow__(self, other: Quantity[Dimensionless, Any] | float) -> Quantity[Any, Any]:
+        if isinstance(other, Quantity):
+            self._check_comparable_magnitudes(self.m, other.m, "combine")  # ty: ignore[invalid-argument-type]
         ret = cast("Quantity[DT, MT]", self._pint_super.__pow__(other))
         return self._call_subclass(ret.m, ret.u)
 
@@ -2235,6 +2262,8 @@ class Quantity(
     @overload
     def __add__(self: Quantity[DT, float], other: Quantity[DT, MT_]) -> Quantity[DT, MT_]: ...
     def __add__(self, other: Quantity[Any, Any] | float) -> Quantity[Any, Any]:
+        if isinstance(other, Quantity):
+            self._check_comparable_magnitudes(self.m, other.m, "combine")  # ty: ignore[invalid-argument-type]
         try:
             self.check_compatibility(other)
         except DimensionalityTypeError as e:
@@ -2293,6 +2322,8 @@ class Quantity(
     @overload
     def __sub__(self: Quantity[DT, float], other: Quantity[DT, MT_]) -> Quantity[DT, MT_]: ...
     def __sub__(self, other: Quantity[Any, Any] | float) -> Quantity[Any, Any]:
+        if isinstance(other, Quantity):
+            self._check_comparable_magnitudes(self.m, other.m, "combine")  # ty: ignore[invalid-argument-type]
         try:
             self.check_compatibility(other)
         except DimensionalityTypeError as e:
@@ -3121,6 +3152,8 @@ class Quantity(
     @overload
     def __mul__(self, other: Quantity[DT_, MT]) -> Quantity[UnknownDimensionality, MT]: ...
     def __mul__(self, other: Quantity[Any, Any] | float) -> Quantity[Any, Any]:
+        if isinstance(other, Quantity):
+            self._check_comparable_magnitudes(self.m, other.m, "combine")  # ty: ignore[invalid-argument-type]
         ret = cast("Quantity[DT, MT]", self._pint_super.__mul__(other))
 
         # preserve the dimensionality for other
@@ -3589,6 +3622,8 @@ class Quantity(
     @overload
     def __truediv__(self, other: Quantity[DT_, MT]) -> Quantity[UnknownDimensionality, MT]: ...
     def __truediv__(self, other: Quantity[Any, Any] | float) -> Quantity[Any, Any]:
+        if isinstance(other, Quantity):
+            self._check_comparable_magnitudes(self.m, other.m, "combine")  # ty: ignore[invalid-argument-type]
         ret = cast("Quantity[DT, MT]", self._pint_super.__truediv__(other))
 
         # preserve the dimensionality for other
@@ -3641,14 +3676,27 @@ class Quantity(
     @overload
     def __floordiv__(self: Quantity[DT, MT], other: float) -> Quantity[DT, MT]: ...
     def __floordiv__(self, other: Quantity[Any, Any] | float) -> Quantity[Any, Any]:
+        if isinstance(other, Quantity):
+            self._check_comparable_magnitudes(self.m, other.m, "combine")  # ty: ignore[invalid-argument-type]
+
         if isinstance(other, (float, int)):
-            return self._call_subclass(cast("MT", self.m // other), self.u)
-        elif other.dimensionless:
-            return self._call_subclass(self.m // other.to_base_units().m, self.u)
+            return self._call_subclass(cast("MT", self._floor_magnitude(self.m / other)), self.u)
+
+        if other.dimensionless:
+            magnitude = self._floor_magnitude(self.m / other.to_base_units().m)
+            return self._call_subclass(magnitude, self.u)
 
         ret = self._pint_super.__floordiv__(other)
+        if self.is_compatible_with(other):
+            divisor = other.to(self.u).m
+        else:
+            return self._call_subclass(ret.m, ret.u)
 
-        return self._call_subclass(ret.m, ret.u)
+        # Floor the quotient rather than using each container's `//` kernel: Python
+        # and numpy implement floating floor-division with subtly different rounding
+        # from Polars (e.g. 1 m // 1 cm used to be 99 vs 100).
+        magnitude = self._floor_magnitude(self.m / divisor)
+        return self._call_subclass(magnitude, ret.u)
 
     def __ifloordiv__(self, other: Any) -> Any:  # noqa: ANN401
         return cast("Quantity[Any, Any]", cast(Any, self).__floordiv__(other))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "encomp"
-version = "1.9.0"
+version = "1.9.1"
 description = "General-purpose library for engineering computations"
 authors = [{ name = "William Laurén", email = "lauren.william.a@gmail.com" }]
 requires-python = ">=3.13"
@@ -120,13 +120,6 @@ test-command = 'python -c "import encomp.coolprop as cp; assert cp.self_check()"
 # the manylinux image lacks Rust (needed by maturin); install it + cmake, then build
 before-all = "curl -sSf https://sh.rustup.rs | sh -s -- -y && pip install cmake && python {project}/scripts/build_libcoolprop.py"
 environment = { PATH = "$HOME/.cargo/bin:$PATH" }
-
-[tool.cibuildwheel.macos]
-# CoolProp uses std::filesystem, unavailable in Apple libc++ below macOS 10.15, so the
-# bundled libCoolProp is built at that floor (scripts/build_libcoolprop.py). Tag the wheel
-# to match so its stated minimum doesn't undercut the dylib; cibuildwheel raises this to
-# 11.0 for arm64 automatically.
-environment = { MACOSX_DEPLOYMENT_TARGET = "10.15" }
 
 [tool.ruff]
 lint.select = [

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1506,9 +1506,11 @@ dependencies = [
  "polars-core",
  "polars-error",
  "polars-expr",
+ "polars-io",
  "polars-lazy",
  "polars-ops",
  "polars-plan",
+ "polars-time",
  "polars-utils",
  "version_check",
 ]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -26,9 +26,16 @@ extension-module = ["pyo3/extension-module"]
 # must match the host polars or it won't load (see README).
 # dtype-extension: without it, an extension-typed input column (e.g. encomp's
 # "encomp.unit" dtype) PANICS inside the FFI field import (polars-core
-# from_arrow_field) before any plugin code runs. With it, the dtype arrives intact
-# and lib.rs refuses it with an actionable schema-time error instead.
-polars = { version = "0.54.4", default-features = false, features = ["dtype-extension"] }
+# from_arrow_field) before any plugin code runs. The small-integer features are
+# likewise required by pyo3-polars' Series import; without them ordinary i8/i16/u8/u16
+# columns panic in the generated wrapper before plugin validation or casting runs.
+polars = { version = "0.54.4", default-features = false, features = [
+    "dtype-extension",
+    "dtype-i8",
+    "dtype-i16",
+    "dtype-u8",
+    "dtype-u16",
+] }
 pyo3-polars = { version = "0.27.0", features = ["derive"] }
 pyo3 = { version = "0.28", features = ["abi3-py313"] }
 serde = { version = "1", features = ["derive"] }

--- a/rust/src/coolprop.rs
+++ b/rust/src/coolprop.rs
@@ -444,7 +444,7 @@ impl State<'_> {
     /// errors already surfaced from `state()`.
     pub fn update_and_1_out(
         &mut self,
-        input_pair: i64, // cast to c_long at the FFI call: c_long is i32 on Windows (LLP64)
+        input_pair: i64,
         v1: &[f64],
         v2: &[f64],
         out_key: c_long,
@@ -461,6 +461,8 @@ impl State<'_> {
                 "update_and_1_out: chunk of {n} rows exceeds the C API length limit"
             ))
         })?;
+        let pair = c_long::try_from(input_pair)
+            .map_err(|_| CpError(format!("input pair {input_pair} exceeds the C API integer range")))?;
         out.fill(f64::NAN);
         let mut err: c_long = 0;
         let mut msg = [0 as c_char; BUFLEN as usize];
@@ -470,7 +472,7 @@ impl State<'_> {
         unsafe {
             (self.cp.batch1)(
                 self.handle,
-                input_pair as c_long,
+                pair,
                 v1.as_ptr(),
                 v2.as_ptr(),
                 n_c,

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -157,6 +157,26 @@ fn validate_extension_input(kind: &str, name: &str, dtype: &DataType, expected_u
     ))
 }
 
+/// Accept only plain numeric columns (or Null, so an all-null column can flow to an
+/// all-null result). Extension inputs are validated separately and compute on their
+/// numeric storage. In particular, do not let Polars' non-strict f64 cast turn Boolean
+/// or numeric-looking String sensor columns into physical values.
+fn validate_numeric_input(kind: &str, name: &str, dtype: &DataType) -> PolarsResult<()> {
+    let storage = match dtype {
+        DataType::Extension(_, storage) => storage.as_ref(),
+        other => other,
+    };
+    if storage.is_primitive_numeric() || storage == &DataType::Null {
+        return Ok(());
+    }
+    Err(PolarsError::InvalidOperation(
+        format!(
+            "{kind}: input '{name}' must be a numeric column, got {dtype}. Boolean, String, nested, and temporal columns cannot represent a CoolProp state input."
+        )
+        .into(),
+    ))
+}
+
 /// Broadcast a length-1 input to `n` (Polars passes a scalar `pl.lit` input as
 /// length 1 alongside full columns; map_batches broadcasts via its struct, we
 /// must do it here). No copy when the length already matches.
@@ -187,10 +207,9 @@ fn broadcast_len(values: &[Vec<f64>], scalar_mask: &[bool]) -> usize {
     n.unwrap_or_else(|| values.iter().map(Vec::len).max().unwrap_or(0))
 }
 
-/// Materialize a Series as `Vec<f64>` with nulls mapped to NaN. CoolProp turns a NaN
-/// input into a failed flash (NaN output -> null via `nan_to_null`), so a null input
-/// row becomes a null output row -- matching the eager numpy path, rather than the old
-/// `cont_slice()` hard error on the first null (nulls are ubiquitous in real frames).
+/// Materialize a Series as `Vec<f64>` with nulls mapped to NaN. The kernels explicitly
+/// mask every row containing a non-finite input after evaluation: some backends return
+/// finite state-independent constants for a NaN input instead of failing the flash.
 fn to_f64(s: &Series) -> PolarsResult<Vec<f64>> {
     // to_storage: an accepted extension-typed input (validate_extension_input) computes
     // on its storage values; the identity for plain columns
@@ -286,9 +305,12 @@ fn evaluate_scalar_fluid(
         };
         let output = std::ffi::c_long::try_from(output)
             .map_err(|_| CpError(format!("output parameter {output} exceeds the C API integer range")))?;
-        let value = entry.1.update_and_1_out_scalar(input_pair, value1, value2, output)?;
+        let value = entry.1.update_and_1_out_scalar(input_pair, value1, value2, output);
+        // A failed flash does not invalidate the AbstractState. Return it to the LRU
+        // before propagating the error so intermittent bad sensor rows do not turn
+        // every following scalar evaluation into a cold state construction.
         cache.entries.push_back(entry);
-        Ok(value)
+        value
     })
 }
 
@@ -428,8 +450,10 @@ fn extract_fractions(fluid: &str) -> Result<(String, Option<Vec<f64>>), CpError>
             .parse::<f64>()
             .map_err(|_| CpError(format!("invalid incompressible concentration {fluid:?}")))?
             * 0.01;
-        if !fraction.is_finite() {
-            return Err(CpError(format!("invalid incompressible concentration {fluid:?}")));
+        if !fraction.is_finite() || !(0.0..=1.0).contains(&fraction) {
+            return Err(CpError(format!(
+                "incompressible concentration {fluid:?} must be between 0% and 100% inclusive"
+            )));
         }
         return Ok((parts[0].to_string(), Some(vec![fraction])));
     }
@@ -658,6 +682,7 @@ fn cp_output(input_fields: &[Field], kwargs: EvalKwargs) -> PolarsResult<Field> 
             f.dtype(),
             expected_unit(&kwargs.expected_units, i),
         )?;
+        validate_numeric_input("cp_evaluate", f.name(), f.dtype())?;
     }
     let dtypes: Vec<DataType> = input_fields.iter().map(|f| f.dtype().clone()).collect();
     Ok(Field::new(
@@ -675,6 +700,7 @@ fn ha_output(input_fields: &[Field], kwargs: HaKwargs) -> PolarsResult<Field> {
             f.dtype(),
             expected_unit(&kwargs.expected_units, i),
         )?;
+        validate_numeric_input("ha_evaluate", f.name(), f.dtype())?;
     }
     let dtypes: Vec<DataType> = input_fields.iter().map(|f| f.dtype().clone()).collect();
     Ok(Field::new(
@@ -715,6 +741,7 @@ fn cp_evaluate(inputs: &[Series], kwargs: EvalKwargs) -> PolarsResult<Series> {
             s.dtype(),
             expected_unit(&kwargs.expected_units, i),
         )?;
+        validate_numeric_input("cp_evaluate", s.name(), s.dtype())?;
     }
     let cp = coolprop(&kwargs.lib_path)?;
     // warm THIS (backend, fluid) once, single-threaded, before the parallel flash below
@@ -748,6 +775,11 @@ fn cp_evaluate(inputs: &[Series], kwargs: EvalKwargs) -> PolarsResult<Series> {
 
     let mut out = vec![0.0f64; n]; // update_and_1_out fills finite-or-NaN (failed rows -> NaN)
     st.update_and_1_out(pair, &v1, &v2, okey, &mut out).map_err(perr)?;
+    for ((result, a), b) in out.iter_mut().zip(v1.iter()).zip(v2.iter()) {
+        if !a.is_finite() || !b.is_finite() {
+            *result = f64::NAN;
+        }
+    }
     nan_to_null(out).cast(&out_dtype)
 }
 
@@ -859,6 +891,7 @@ fn ha_evaluate(inputs: &[Series], kwargs: HaKwargs) -> PolarsResult<Series> {
             s.dtype(),
             expected_unit(&kwargs.expected_units, i),
         )?;
+        validate_numeric_input("ha_evaluate", s.name(), s.dtype())?;
     }
     let cp = coolprop(&kwargs.lib_path)?;
     cp.ensure_warmed_humid_air().map_err(perr)?; // one-time HAPropsSI global init, single-threaded
@@ -881,5 +914,10 @@ fn ha_evaluate(inputs: &[Series], kwargs: HaKwargs) -> PolarsResult<Series> {
         &mut out,
     )
     .map_err(perr)?;
+    for (((result, a), b), c) in out.iter_mut().zip(b0.iter()).zip(b1.iter()).zip(b2.iter()) {
+        if !a.is_finite() || !b.is_finite() || !c.is_finite() {
+            *result = f64::NAN;
+        }
+    }
     nan_to_null(out).cast(&out_dtype)
 }

--- a/uv.lock
+++ b/uv.lock
@@ -514,7 +514,7 @@ wheels = [
 
 [[package]]
 name = "encomp"
-version = "1.9.0"
+version = "1.9.1"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },


### PR DESCRIPTION
## Summary

Resolve every actionable finding in the holistic 1.9.0 review and prepare patch release 1.9.1.

### Correctness and consistency

- mask every plugin row with a non-finite CoolProp input, including IF97 trivial/state-independent outputs
- treat a single-species bracket fraction as an absolute concentration only for `INCOMP`; `HEOS::CO2[0.5]` now raises, while `[1.0]` remains accepted
- require fractions for multi-species names instead of degrading missing mixture configuration to NaN
- validate Polars Series magnitudes as numeric, normalize integer/empty Series to Float64, and reject bool/string/list/datetime/unit-typed Series
- refuse implicit absolute-temperature ↔ temperature-difference reinterpretation when reading `QuantityFrame` data
- propagate unsupported scalar CoolProp input pairs consistently with array/expression paths
- make floor division use divide-then-floor semantics across float, numpy, Series, and Expr magnitudes
- reject mixed vector-container arithmetic before numpy/pint/polars dispatch can become state-dependent
- reject Expr → Series `astype` instead of creating an Object Series
- share Quantity unit spelling normalization with the Polars dtype layer and turn malformed tokenizer failures into `UndefinedUnitError`

### Native/plugin and maintenance

- enable i8/i16/u8/u16 Polars features so small-integer inputs cannot panic the generated wrapper
- reject nonnumeric plugin columns instead of non-strictly casting bool/string values
- retain scalar states after a failed flash
- range-check percent-form INCOMP concentrations
- use a checked `c_long` conversion for input pairs on Windows
- tighten installed-wheel docs-root discovery
- refresh stale docs/output/size/license wording and remove the vestigial macOS 10.15 override (arm64 correctly defaults to 11.0)
- bump `pyproject.toml` and `uv.lock` to 1.9.1

### Compatibility note

This deliberately tightens accepted inputs: CoolProp's high-level parser silently ignores a single-species HEOS fraction, while its low-level state API can compute with the unnormalised vector. encomp now consistently requires non-INCOMP fractions to sum to one, so `HEOS::CO2[0.5]` raises instead of returning silently wrong physics.

## Local validation

- `ruff check` / `ruff format --check`
- pyright strict, pyrefly, ty: zero errors
- `cargo fmt --check`, clippy `-D warnings`, Rust tests: pass
- full default suite without Python CoolProp: 1050 passed, 2 expected oracle skips
- explicit CoolProp 8.0.0 oracle parity: 100 passed
- local and Read the Docs-parity Sphinx builds with warnings as errors: pass
- locally built `encomp-1.9.1-cp313-abi3-macosx_11_0_arm64.whl` installed in a fresh external Python 3.14 env against current PyPI dependencies (including Polars 1.43), native self-check passed, no Python CoolProp installed, shipped suite: 797 passed, 20 expected skips
