### PR TITLE
fix: preserve temperature meaning and release 1.9.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,13 @@ Common dimensionalities are defined in the `encomp.utypes` module.
 A newly created dimensionality gets a class name of the form `Dimensionality[...]` (for example `Quantity[Dimensionality[[mass] ** 2 / [length] ** 3]]`).
 The second type parameter is the magnitude container. It defaults to `Numpy1DArray`, so annotate scalar quantities explicitly as `Quantity[Pressure, float]` (or `Q[Pressure, float]`).
 
+`Temperature` and `TemperatureDifference` deliberately remain distinct even though
+both have the physical dimension `[temperature]`. Offset units such as `degC` and
+`degF` denote absolute temperatures; `delta_degC` and `delta_degF` denote
+differences. Multiplicative units such as `K` and `degR` can express either concept,
+but default to absolute `Temperature`; use `.asdim(TemperatureDifference)` when a
+value in one of those units explicitly represents a difference.
+
 ```python
 from typing import Any
 
@@ -260,6 +267,13 @@ The boundary is explicit in both directions:
 3. `Report.power.assign(power)` checks dimensionality, and `Report.derive(...)` converts to `kW` and restores its metadata without collecting.
 
 Use `unit("bar", name="Suction pressure")` when an external column name cannot be the Python attribute. Registered unit literals infer dimensionality for static checkers. Pint still accepts its open unit grammar: an unlisted spelling such as `unit("kg/(m*s**2)")` is inferred at runtime and typed conservatively as unknown; add `asdim=Pressure` when precise static typing is required. The override is validated rather than cast.
+
+For temperature columns, persisted `K` or `degR` metadata is inherently ambiguous
+between an absolute temperature and a difference. A declaration such as `unit("K")`
+means absolute `Temperature`; use `unit("K", asdim=TemperatureDifference)` to
+declare difference data explicitly. Explicit delta metadata such as `delta_degC`
+cannot be read through an absolute-temperature declaration without an explicit
+`asdim=` override.
 
 The validated expressions pass directly into the high-level fluid API. Non-SI declarations are converted before the native plugin runs, and the result can be persisted with another declaration:
 

--- a/encomp/polars.py
+++ b/encomp/polars.py
@@ -33,7 +33,7 @@ import polars as pl
 
 from . import utypes as _ut
 from ._polars_dtype import EXTENSION_NAME, UnitDType
-from .units import Quantity, Unit
+from .units import DimensionalityTypeError, Quantity, Unit
 from .utypes import Dimensionality, UnknownDimensionality
 
 __all__ = [
@@ -55,10 +55,18 @@ class Column[DT: Dimensionality]:
     validated schema instance returns a ``Quantity[DT, pl.Expr]``.
     """
 
-    def __init__(self, value: str | Unit[Any], dimensionality: type[DT], *, name: str | None = None) -> None:
+    def __init__(
+        self,
+        value: str | Unit[Any],
+        dimensionality: type[DT],
+        *,
+        name: str | None = None,
+        _explicit_dimensionality: bool = True,
+    ) -> None:
         validated = Quantity(1.0, value).asdim(dimensionality)
         self.unit = validated.u
         self.dimensionality = dimensionality
+        self._explicit_dimensionality = _explicit_dimensionality
         self._explicit_name = name
         self._attribute_name: str | None = None
 
@@ -73,6 +81,11 @@ class Column[DT: Dimensionality]:
         if self._attribute_name is None:
             raise RuntimeError("unit column declaration is not bound to a QuantityFrame class")
         return self._attribute_name
+
+    @property
+    def dimensionality_is_explicit(self) -> bool:
+        """Whether the declaration explicitly selected its dimensionality."""
+        return self._explicit_dimensionality
 
     @overload
     def __get__(self, instance: None, owner: type[object] | None = None) -> Column[DT]: ...
@@ -305,7 +318,7 @@ def unit(
     """
     probe = Quantity(1.0, value)
     dimensionality = probe.dt if asdim is None else asdim
-    return Column(probe.u, dimensionality, name=name)
+    return Column(probe.u, dimensionality, name=name, _explicit_dimensionality=asdim is not None)
 
 
 class QuantityFrame:
@@ -355,12 +368,21 @@ class QuantityFrame:
                 continue
 
             # Persisted units are data, not an instruction to reinterpret physical
-            # meaning. Ordinary compatible-unit conversions are allowed, while `.to`
-            # deliberately refuses absolute-temperature ↔ temperature-difference
-            # crossings. `asdim` remains available only at the explicit declaration
-            # boundary (`unit(..., asdim=...)`).
+            # meaning. Pint permits scale-only conversions such as delta_degC -> K,
+            # so compare semantic dimensionality after converting as well.
             source = Quantity(pl.col(declaration.name).ext.storage(), dtype.unit)
-            converted = source.to(declaration.unit).m.alias(declaration.name)
+            converted_quantity = source.to(declaration.unit)
+            if converted_quantity.dt is not declaration.dimensionality:
+                if not declaration.dimensionality_is_explicit:
+                    raise DimensionalityTypeError(
+                        f"Cannot read column {declaration.name!r} carrying {dtype.unit} "
+                        f"(dimensionality {converted_quantity.dt.__name__}) as {declaration.unit} "
+                        f"(dimensionality {declaration.dimensionality.__name__}); use unit(..., asdim=...) "
+                        "to explicitly reinterpret it"
+                    )
+                converted_quantity = converted_quantity.asdim(declaration.dimensionality)
+
+            converted = converted_quantity.m.alias(declaration.name)
             storage = lf.select(converted).collect_schema()[declaration.name]
             conversions.append(converted.ext.to(UnitDType(declaration.unit, storage=storage)).alias(declaration.name))
 

--- a/encomp/tests/test_polars_units.py
+++ b/encomp/tests/test_polars_units.py
@@ -27,8 +27,8 @@ from ..polars import (
     units_of,
     with_units,
 )
+from ..units import DimensionalityTypeError, Unit
 from ..units import Quantity as Q
-from ..units import Unit
 from ..utypes import (
     Density,
     Power,
@@ -117,16 +117,43 @@ def test_quantity_frame_refuses_temperature_reinterpretation() -> None:
     class Absolute(QuantityFrame):
         value = unit("degC")
 
+    class KelvinAbsolute(QuantityFrame):
+        value = unit("K")
+
+    class RankineAbsolute(QuantityFrame):
+        value = unit("degR")
+
     class Difference(QuantityFrame):
         value = unit("delta_degC")
 
+    class ExplicitAbsolute(QuantityFrame):
+        value = unit("K", asdim=Temperature)
+
+    class KelvinDifference(QuantityFrame):
+        value = unit("K", asdim=TemperatureDifference)
+
     absolute = with_units(pl.DataFrame({"value": [25.0]}), {"value": "degC"})
     difference = with_units(pl.DataFrame({"value": [5.0]}), {"value": "delta_degC"})
+    ambiguous_kelvin = with_units(pl.DataFrame({"value": [5.0]}), {"value": "K"})
 
-    with raises(Exception, match=r"[Tt]emperature"):
+    with raises(DimensionalityTypeError, match=r"[Tt]emperature"):
         Difference(absolute)
-    with raises(Exception, match=r"[Tt]emperature"):
+    with raises(DimensionalityTypeError, match=r"[Tt]emperature"):
         Absolute(difference)
+    with raises(DimensionalityTypeError, match=r"TemperatureDifference.*Temperature"):
+        KelvinAbsolute(difference)
+    with raises(DimensionalityTypeError, match=r"TemperatureDifference.*Temperature"):
+        RankineAbsolute(difference)
+
+    kelvin = KelvinAbsolute(absolute)
+    assert kelvin.lf.select(kelvin.value.m).collect().item() == pytest.approx(298.15)
+
+    explicitly_reinterpreted = ExplicitAbsolute(difference)
+    assert explicitly_reinterpreted.lf.select(explicitly_reinterpreted.value.m).collect().item() == 5.0
+
+    assert KelvinAbsolute(ambiguous_kelvin).value.dt is Temperature
+    assert KelvinDifference(ambiguous_kelvin).value.dt is TemperatureDifference
+    assert KelvinDifference(difference).lf.select(pl.col("value").ext.storage()).collect().item() == 5.0
 
     assert_type(Absolute.value, Column[Temperature])
     assert_type(Difference.value, Column[TemperatureDifference])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "encomp"
-version = "1.9.1"
+version = "1.9.2"
 description = "General-purpose library for engineering computations"
 authors = [{ name = "William Laurén", email = "lauren.william.a@gmail.com" }]
 requires-python = ">=3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -514,7 +514,7 @@ wheels = [
 
 [[package]]
 name = "encomp"
-version = "1.9.1"
+version = "1.9.2"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },


### PR DESCRIPTION
## Summary

- reject persisted `TemperatureDifference` columns when a default absolute `K` or `degR` schema would silently reinterpret them
- retain `unit(..., asdim=...)` as the explicit, value-preserving reinterpretation boundary
- document the absolute/difference meaning of offset and multiplicative temperature units, including the inherent ambiguity of persisted `K`/`degR` metadata
- add regression coverage for default rejection, ordinary absolute conversion, explicit reinterpretation, and schema disambiguation of persisted `K`
- bump `pyproject.toml` and `uv.lock` to 1.9.2

The published v1.9.1 release notes were also corrected in place: `INCOMP::MEG[0.5]` / `INCOMP::MEG-50%` replace the invalid `INCOMP::MEG[50%]` example, and the compatibility note now names the Series dtype, mixed-container, and floor-division behavior changes.

## Temperature contract

- `degC` / `degF`: absolute `Temperature`
- `delta_degC` / `delta_degF`: `TemperatureDifference`
- `K` / `degR`: usable for either, defaulting to absolute `Temperature`
- ambiguous persisted `K` / `degR`: interpreted by the `QuantityFrame` declaration
- `asdim=`: explicit opt-in to semantic reinterpretation

## Local validation

- `uv lock --check`
- `ruff check` / `ruff format --check`
- pyright strict, pyrefly, ty: zero errors
- full default suite: 1050 passed, 2 expected oracle skips
- Sphinx HTML build with warnings as errors
- exact CI Rust fmt, clippy `-D warnings`, and no-default-features tests: pass
