### PR TITLE
feat!: require an explicit fluid_name in encomp.gases (breaking)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,7 +65,9 @@ assert pressure.to("kPa").m == 100.0
 - **No implicit physical identities.** A fluid name, density or similar physical
   identity is never defaulted — APIs require it explicitly (`cp.fluid(name=...)`;
   `cp.water()` exists for the common case). Don't add parameter defaults that encode
-  physics.
+  physics. There are no exceptions left: `encomp.gases`' `fluid_name` was the last one and
+  is required and keyword-only since 1.9.4. A wrong fluid returns plausible numbers
+  instead of raising, which is exactly why it may not be guessed.
 - `bool` magnitudes are rejected at runtime (a bool is always a mistake), `int`
   magnitudes normalize to `float`, and only 1-D arrays are accepted.
 - `Temperature` and `TemperatureDifference` are distinct dimensionalities with

--- a/encomp/gases.py
+++ b/encomp/gases.py
@@ -17,6 +17,11 @@ The functions here name their fluid parameter ``fluid_name``, whereas
 inconsistency: ``name`` is unambiguous on a fluid object, while a free function that
 also takes volumes, masses and conditions has to say *whose* name it is.
 
+``fluid_name`` is **required** and keyword-only, like ``encomp.coolprop.fluid``'s
+``name=`` and ``convert_volume_mass``'s density: a fluid identity is never defaulted,
+because a wrong one silently returns plausible numbers for the wrong gas. It used to
+default to ``"Air"``; pass ``fluid_name="Air"`` explicitly to keep that behavior.
+
 .. note::
     Humid-air-specific conversions are not implemented here; use
     :class:`encomp.fluids.HumidAir` for humid-air properties.
@@ -157,7 +162,8 @@ def convert_gas_volume(
     V1: Quantity[Volume, MT],
     condition_1: GasConditionInput = "N",
     condition_2: GasConditionInput = "N",
-    fluid_name: str = "Air",
+    *,
+    fluid_name: str,
 ) -> Quantity[Volume, MT]: ...
 
 
@@ -166,7 +172,8 @@ def convert_gas_volume(
     V1: Quantity[VolumeFlow, MT],
     condition_1: GasConditionInput = "N",
     condition_2: GasConditionInput = "N",
-    fluid_name: str = "Air",
+    *,
+    fluid_name: str,
 ) -> Quantity[VolumeFlow, MT]: ...
 
 
@@ -174,7 +181,8 @@ def convert_gas_volume(
     V1: Quantity[Volume, Any] | Quantity[VolumeFlow, Any],
     condition_1: GasConditionInput = "N",
     condition_2: GasConditionInput = "N",
-    fluid_name: str = "Air",
+    *,
+    fluid_name: str,
 ) -> Quantity[Volume, Any] | Quantity[VolumeFlow, Any]:
     """
     Converts the volume :math:`V_1` (at :math:`T_1, P_1`) to
@@ -203,8 +211,8 @@ def convert_gas_volume(
     condition_2 : tuple[Quantity[Pressure, Any], Quantity[Temperature, Any]] |
                   Literal['N', 'S'], optional
         Pressure and temperature at condition 2, by default 'N'
-    fluid_name : str, optional
-        CoolProp name of the fluid, by default 'Air'
+    fluid_name : str
+        CoolProp name of the gas, e.g. ``"Air"`` or ``"Nitrogen"`` (required)
 
     Returns
     -------
@@ -268,15 +276,15 @@ def _strip_normal(
 
 
 @overload
-def mass_to_normal_volume(mass: Quantity[Mass, MT], fluid_name: str = "Air") -> Quantity[NormalVolume, MT]: ...
+def mass_to_normal_volume(mass: Quantity[Mass, MT], *, fluid_name: str) -> Quantity[NormalVolume, MT]: ...
 
 
 @overload
-def mass_to_normal_volume(mass: Quantity[MassFlow, MT], fluid_name: str = "Air") -> Quantity[NormalVolumeFlow, MT]: ...
+def mass_to_normal_volume(mass: Quantity[MassFlow, MT], *, fluid_name: str) -> Quantity[NormalVolumeFlow, MT]: ...
 
 
 def mass_to_normal_volume(
-    mass: Quantity[Mass, Any] | Quantity[MassFlow, Any], fluid_name: str = "Air"
+    mass: Quantity[Mass, Any] | Quantity[MassFlow, Any], *, fluid_name: str
 ) -> Quantity[NormalVolume, Any] | Quantity[NormalVolumeFlow, Any]:
     """
     Convert mass to normal volume.
@@ -285,8 +293,8 @@ def mass_to_normal_volume(
     ----------
     mass : Quantity[Mass, MT] | Quantity[MassFlow, MT]
         Input mass or mass flow
-    fluid_name : str, optional
-        Name of the fluid, by default 'Air'
+    fluid_name : str
+        CoolProp name of the gas, e.g. ``"Air"`` or ``"Nitrogen"`` (required)
 
     Returns
     -------
@@ -309,7 +317,8 @@ def mass_to_normal_volume(
 def mass_to_actual_volume(
     mass: Quantity[Mass, MT],
     condition: GasConditionInput,
-    fluid_name: str = "Air",
+    *,
+    fluid_name: str,
 ) -> Quantity[Volume, MT]: ...
 
 
@@ -317,14 +326,16 @@ def mass_to_actual_volume(
 def mass_to_actual_volume(
     mass: Quantity[MassFlow, MT],
     condition: GasConditionInput,
-    fluid_name: str = "Air",
+    *,
+    fluid_name: str,
 ) -> Quantity[VolumeFlow, MT]: ...
 
 
 def mass_to_actual_volume(
     mass: Quantity[Mass, Any] | Quantity[MassFlow, Any],
     condition: GasConditionInput,
-    fluid_name: str = "Air",
+    *,
+    fluid_name: str,
 ) -> Quantity[Volume, Any] | Quantity[VolumeFlow, Any]:
     """
     Convert mass to actual volume.
@@ -335,8 +346,8 @@ def mass_to_actual_volume(
         Input mass or mass flow
     condition : tuple[Quantity[Pressure, Any], Quantity[Temperature, Any]] | Literal['N', 'S']
         Condition at which to calculate the actual volume
-    fluid_name : str, optional
-        Name of the fluid, by default 'Air'
+    fluid_name : str
+        CoolProp name of the gas, e.g. ``"Air"`` or ``"Nitrogen"`` (required)
 
     Returns
     -------
@@ -353,13 +364,11 @@ def mass_to_actual_volume(
 
 
 @overload
-def mass_from_normal_volume(volume: Quantity[NormalVolume, MT], fluid_name: str = "Air") -> Quantity[Mass, MT]: ...
+def mass_from_normal_volume(volume: Quantity[NormalVolume, MT], *, fluid_name: str) -> Quantity[Mass, MT]: ...
 
 
 @overload
-def mass_from_normal_volume(
-    volume: Quantity[NormalVolumeFlow, MT], fluid_name: str = "Air"
-) -> Quantity[MassFlow, MT]: ...
+def mass_from_normal_volume(volume: Quantity[NormalVolumeFlow, MT], *, fluid_name: str) -> Quantity[MassFlow, MT]: ...
 
 
 def mass_from_normal_volume(
@@ -369,7 +378,8 @@ def mass_from_normal_volume(
         | Quantity[Volume, Any]
         | Quantity[VolumeFlow, Any]
     ),
-    fluid_name: str = "Air",
+    *,
+    fluid_name: str,
 ) -> Quantity[Mass, Any] | Quantity[MassFlow, Any]:
     """
     Convert normal volume to mass.
@@ -382,8 +392,8 @@ def mass_from_normal_volume(
     ----------
     volume : Quantity[NormalVolume, MT] | Quantity[NormalVolumeFlow, MT]
         Input normal volume or normal volume flow
-    fluid_name : str, optional
-        Name of the fluid, by default 'Air'
+    fluid_name : str
+        CoolProp name of the gas, e.g. ``"Air"`` or ``"Nitrogen"`` (required)
 
     Returns
     -------
@@ -406,7 +416,8 @@ def mass_from_normal_volume(
 def mass_from_actual_volume(
     volume: Quantity[Volume, MT],
     condition: GasConditionInput,
-    fluid_name: str = "Air",
+    *,
+    fluid_name: str,
 ) -> Quantity[Mass, MT]: ...
 
 
@@ -414,14 +425,16 @@ def mass_from_actual_volume(
 def mass_from_actual_volume(
     volume: Quantity[VolumeFlow, MT],
     condition: GasConditionInput,
-    fluid_name: str = "Air",
+    *,
+    fluid_name: str,
 ) -> Quantity[MassFlow, MT]: ...
 
 
 def mass_from_actual_volume(
     volume: Quantity[Volume, Any] | Quantity[VolumeFlow, Any],
     condition: GasConditionInput,
-    fluid_name: str = "Air",
+    *,
+    fluid_name: str,
 ) -> Quantity[Mass, Any] | Quantity[MassFlow, Any]:
     """
     Convert actual volume to mass.
@@ -432,8 +445,8 @@ def mass_from_actual_volume(
         Input actual volume or actual volume flow
     condition : tuple[Quantity[Pressure, Any], Quantity[Temperature, Any]] | Literal['N', 'S']
         Condition at which to calculate the mass
-    fluid_name : str, optional
-        Name of the fluid, by default 'Air'
+    fluid_name : str
+        CoolProp name of the gas, e.g. ``"Air"`` or ``"Nitrogen"`` (required)
 
     Returns
     -------
@@ -453,7 +466,8 @@ def mass_from_actual_volume(
 def actual_volume_to_normal_volume(
     volume: Quantity[Volume, Any],
     condition: GasConditionInput,
-    fluid_name: str = "Air",
+    *,
+    fluid_name: str,
 ) -> Quantity[NormalVolume, Any]: ...
 
 
@@ -461,14 +475,16 @@ def actual_volume_to_normal_volume(
 def actual_volume_to_normal_volume(
     volume: Quantity[VolumeFlow, Any],
     condition: GasConditionInput,
-    fluid_name: str = "Air",
+    *,
+    fluid_name: str,
 ) -> Quantity[NormalVolumeFlow, Any]: ...
 
 
 def actual_volume_to_normal_volume(
     volume: Quantity[Volume, Any] | Quantity[VolumeFlow, Any],
     condition: GasConditionInput,
-    fluid_name: str = "Air",
+    *,
+    fluid_name: str,
 ) -> Quantity[NormalVolume, Any] | Quantity[NormalVolumeFlow, Any]:
     """
     Convert actual volume to normal volume.
@@ -479,8 +495,8 @@ def actual_volume_to_normal_volume(
         Input actual volume or actual volume flow
     condition : tuple[Quantity[Pressure, Any], Quantity[Temperature, Any]] | Literal['N', 'S']
         Condition at which the input volume is evaluated
-    fluid_name : str, optional
-        Name of the fluid, by default 'Air'
+    fluid_name : str
+        CoolProp name of the gas, e.g. ``"Air"`` or ``"Nitrogen"`` (required)
 
     Returns
     -------
@@ -497,7 +513,8 @@ def actual_volume_to_normal_volume(
 def normal_volume_to_actual_volume(
     volume: Quantity[NormalVolume, Any],
     condition: GasConditionInput,
-    fluid_name: str = "Air",
+    *,
+    fluid_name: str,
 ) -> Quantity[Volume, Any]: ...
 
 
@@ -505,7 +522,8 @@ def normal_volume_to_actual_volume(
 def normal_volume_to_actual_volume(
     volume: Quantity[NormalVolumeFlow, Any],
     condition: GasConditionInput,
-    fluid_name: str = "Air",
+    *,
+    fluid_name: str,
 ) -> Quantity[VolumeFlow, Any]: ...
 
 
@@ -517,7 +535,8 @@ def normal_volume_to_actual_volume(
         | Quantity[VolumeFlow, Any]
     ),
     condition: GasConditionInput,
-    fluid_name: str = "Air",
+    *,
+    fluid_name: str,
 ) -> Quantity[Volume, Any] | Quantity[VolumeFlow, Any]:
     """
     Convert normal volume to actual volume.
@@ -532,8 +551,8 @@ def normal_volume_to_actual_volume(
         Input normal volume or normal volume flow
     condition : tuple[Quantity[Pressure, Any], Quantity[Temperature, Any]] | Literal['N', 'S']
         Condition at which to calculate the actual volume
-    fluid_name : str, optional
-        Name of the fluid, by default 'Air'
+    fluid_name : str
+        CoolProp name of the gas, e.g. ``"Air"`` or ``"Nitrogen"`` (required)
 
     Returns
     -------

--- a/encomp/tests/test_gases.py
+++ b/encomp/tests/test_gases.py
@@ -42,31 +42,31 @@ assert_type.__code__ = _assert_type.__code__
 
 def test_convert_gas_volume() -> None:
     # the dimensionality (Volume / VolumeFlow) and units of the input are preserved
-    ret = convert_gas_volume(Q(1, "m3"), "N", (Q(2, "bar"), Q(25, "degC")))
+    ret = convert_gas_volume(Q(1, "m3"), "N", (Q(2, "bar"), Q(25, "degC")), fluid_name="Air")
     assert_type(ret, Q[Volume, float])
     assert ret.check(Q(0, "liter"))
     assert str(ret.u) == str(Q(1, "m3").u)
 
-    ret2 = convert_gas_volume(Q(1, "m3/s"), "S", (Q(2, "bar"), Q(25, "degC")))
+    ret2 = convert_gas_volume(Q(1, "m3/s"), "S", (Q(2, "bar"), Q(25, "degC")), fluid_name="Air")
     assert_type(ret2, Q[VolumeFlow, float])
 
     with pytest.raises(ValueError, match=r"condition_1.*'N'.*'S'"):
-        convert_gas_volume(Q(1, "m3"), cast(Any, "n"), "N")
+        convert_gas_volume(Q(1, "m3"), cast(Any, "n"), "N", fluid_name="Air")
 
     with pytest.raises(ValueError, match=r"condition_1.*'N'.*'S'"):
-        convert_gas_volume(Q(1, "m3"), cast(Any, "NS"), "N")
+        convert_gas_volume(Q(1, "m3"), cast(Any, "NS"), "N", fluid_name="Air")
 
     with pytest.raises(TypeError, match=r"condition_2.*pressure, temperature"):
-        convert_gas_volume(Q(1, "m3"), "N", cast(Any, (Q(1, "bar"),)))
+        convert_gas_volume(Q(1, "m3"), "N", cast(Any, (Q(1, "bar"),)), fluid_name="Air")
 
     with pytest.raises(TypeError, match=r"condition_2.*pressure, temperature"):
-        convert_gas_volume(Q(1, "m3"), "N", cast(Any, (Q(25, "degC"), Q(1, "bar"))))
+        convert_gas_volume(Q(1, "m3"), "N", cast(Any, (Q(25, "degC"), Q(1, "bar"))), fluid_name="Air")
 
     with pytest.raises(TypeError, match="normal_volume_to_actual_volume"):
-        convert_gas_volume(cast(Any, Q(100.0, "Nm³")), "N", (Q(2, "bar"), Q(25, "degC")))
+        convert_gas_volume(cast(Any, Q(100.0, "Nm³")), "N", (Q(2, "bar"), Q(25, "degC")), fluid_name="Air")
 
     with pytest.raises(TypeError, match="normal_volume_to_actual_volume"):
-        convert_gas_volume(cast(Any, Q(100.0, "Nm³/h")), "N", (Q(2, "bar"), Q(25, "degC")))
+        convert_gas_volume(cast(Any, Q(100.0, "Nm³/h")), "N", (Q(2, "bar"), Q(25, "degC")), fluid_name="Air")
 
 
 def test_ideal_gas_density() -> None:
@@ -113,23 +113,23 @@ def test_gas_conversion() -> None:
     P = Q(1, "atm")
     T = Q(25, "degC")
 
-    assert_type(mass_from_actual_volume(V, (P, T)), Q[Mass, float])
-    assert_type(mass_from_actual_volume(V, "N"), Q[Mass, float])
+    assert_type(mass_from_actual_volume(V, (P, T), fluid_name="Air"), Q[Mass, float])
+    assert_type(mass_from_actual_volume(V, "N", fluid_name="Air"), Q[Mass, float])
 
-    assert_type(mass_to_actual_volume(m, (P, T)), Q[Volume, float])
-    assert_type(mass_to_actual_volume(m, "S"), Q[Volume, float])
+    assert_type(mass_to_actual_volume(m, (P, T), fluid_name="Air"), Q[Volume, float])
+    assert_type(mass_to_actual_volume(m, "S", fluid_name="Air"), Q[Volume, float])
 
     # the normal-volume side carries the NormalVolume dimensionality (Nm³)
     # (assert_type also verifies the runtime type via the monkeypatch above; a
     # narrowing `assert isinstance_types(...)` would poison later inference)
-    nv = actual_volume_to_normal_volume(V, (P, T))
+    nv = actual_volume_to_normal_volume(V, (P, T), fluid_name="Air")
     assert_type(nv, Q[NormalVolume, Any])
     assert nv.check(Q(0, "Nm³"))
-    assert_type(actual_volume_to_normal_volume(V, "N"), Q[NormalVolume, Any])
+    assert_type(actual_volume_to_normal_volume(V, "N", fluid_name="Air"), Q[NormalVolume, Any])
 
-    v_actual = normal_volume_to_actual_volume(nv, (P, T))
+    v_actual = normal_volume_to_actual_volume(nv, (P, T), fluid_name="Air")
     assert_type(v_actual, Q[Volume, Any])
-    assert_type(normal_volume_to_actual_volume(nv, "S"), Q[Volume, Any])
+    assert_type(normal_volume_to_actual_volume(nv, "S", fluid_name="Air"), Q[Volume, Any])
 
     # round trip recovers the original value
     assert v_actual.to("liter").m == approx(V.m, rel=1e-9)
@@ -138,21 +138,21 @@ def test_gas_conversion() -> None:
 def test_mass_normal_volume_round_trip() -> None:
     m = Q(1.0, "kg")
 
-    nv = mass_to_normal_volume(m)
+    nv = mass_to_normal_volume(m, fluid_name="Air")
     assert_type(nv, Q[NormalVolume, float])
     # air at 0 °C, 1 atm is roughly 1.276 kg/m³ -> ~0.78 Nm³ per kg
     assert nv.to("Nm³").m == approx(0.78, rel=0.05)
 
-    m_back = mass_from_normal_volume(nv)
+    m_back = mass_from_normal_volume(nv, fluid_name="Air")
     assert_type(m_back, Q[Mass, float])
     assert m_back.to("kg").m == approx(m.m, rel=1e-9)
 
     # flows map to NormalVolumeFlow / MassFlow
     mf = Q(3600.0, "kg/h")
-    nvf = mass_to_normal_volume(mf)
+    nvf = mass_to_normal_volume(mf, fluid_name="Air")
     assert_type(nvf, Q[NormalVolumeFlow, float])
 
-    mf_back = mass_from_normal_volume(nvf)
+    mf_back = mass_from_normal_volume(nvf, fluid_name="Air")
     assert_type(mf_back, Q[MassFlow, float])
     assert mf_back.to("kg/h").m == approx(mf.m, rel=1e-9)
 
@@ -164,17 +164,17 @@ def test_normal_volume_legacy_plain_inputs() -> None:
     T = Q(25.0, "degC")
 
     nv = Q(1.0, "Nm³")
-    v_typed = normal_volume_to_actual_volume(nv, (P, T))
+    v_typed = normal_volume_to_actual_volume(nv, (P, T), fluid_name="Air")
 
     # a legacy caller passes a plain m³ quantity where NormalVolume is expected
     # (statically a lie, hence the cast; the runtime accepts and interprets it)
     legacy = cast("Q[NormalVolume, float]", Q(1.0, "m³"))
 
-    v_legacy = normal_volume_to_actual_volume(legacy, (P, T))
+    v_legacy = normal_volume_to_actual_volume(legacy, (P, T), fluid_name="Air")
     assert v_legacy.to("m³").m == approx(v_typed.to("m³").m, rel=1e-9)
 
-    m_typed = mass_from_normal_volume(nv)
-    m_legacy = mass_from_normal_volume(legacy)
+    m_typed = mass_from_normal_volume(nv, fluid_name="Air")
+    m_legacy = mass_from_normal_volume(legacy, fluid_name="Air")
     assert m_legacy.to("kg").m == approx(m_typed.to("kg").m, rel=1e-9)
 
 
@@ -182,11 +182,35 @@ def test_convert_gas_volume_rejects_invalid_condition_type() -> None:
     # a condition that is neither a recognised string ("N"/"S") nor a
     # (pressure, temperature) tuple is a TypeError, naming the offending argument
     with pytest.raises(TypeError, match="condition_1"):
-        convert_gas_volume(Q(1.0, "m³"), cast(Any, 123), "N")
+        convert_gas_volume(Q(1.0, "m³"), cast(Any, 123), "N", fluid_name="Air")
 
     with pytest.raises(TypeError, match="condition_2"):
-        convert_gas_volume(Q(1.0, "m³"), "N", cast(Any, object()))
+        convert_gas_volume(Q(1.0, "m³"), "N", cast(Any, object()), fluid_name="Air")
 
     # an unrecognised string condition is a ValueError, not a TypeError
     with pytest.raises(ValueError, match="must be 'N', 'S'"):
-        convert_gas_volume(Q(1.0, "m³"), cast(Any, "X"), "N")
+        convert_gas_volume(Q(1.0, "m³"), cast(Any, "X"), "N", fluid_name="Air")
+
+
+def test_fluid_name_is_required_and_keyword_only() -> None:
+    # a fluid identity is never defaulted (it used to default to "Air"): the wrong gas
+    # returns plausible numbers rather than an error, so the caller has to name it. The
+    # type checkers reject these calls as well -- route them through Any to reach the
+    # runtime behavior, which is what an untyped caller hits
+    to_normal_volume = cast(Any, mass_to_normal_volume)
+    convert_volume = cast(Any, convert_gas_volume)
+
+    with pytest.raises(TypeError, match="fluid_name"):
+        to_normal_volume(Q(1.0, "kg"))
+
+    with pytest.raises(TypeError, match="fluid_name"):
+        convert_volume(Q(1.0, "m³"), "N", "S")
+
+    # keyword-only, so it cannot land in a condition parameter positionally
+    with pytest.raises(TypeError, match="positional"):
+        convert_volume(Q(1.0, "m³"), "N", "S", "Air")
+
+    # naming a different gas gives a different answer -- which is why it is required
+    air = mass_to_normal_volume(Q(1.0, "kg"), fluid_name="Air")
+    methane = mass_to_normal_volume(Q(1.0, "kg"), fluid_name="Methane")
+    assert air.to("Nm³").m != pytest.approx(methane.to("Nm³").m, rel=0.1)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "encomp"
-version = "1.9.3"
+version = "1.9.4"
 description = "General-purpose library for engineering computations"
 authors = [{ name = "William Laurén", email = "lauren.william.a@gmail.com" }]
 requires-python = ">=3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -514,7 +514,7 @@ wheels = [
 
 [[package]]
 name = "encomp"
-version = "1.9.3"
+version = "1.9.4"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },


### PR DESCRIPTION
## Breaking change

`encomp.gases`' seven public functions no longer default `fluid_name` to `"Air"`, and the parameter is now **keyword-only**. `ideal_gas_density` is unaffected (it never had a default).

```python
# before
mass_to_normal_volume(mass)
convert_gas_volume(volume, "N", condition)

# after
mass_to_normal_volume(mass, fluid_name="Air")
convert_gas_volume(volume, "N", condition, fluid_name="Air")
```

Affected: `convert_gas_volume`, `mass_to_normal_volume`, `mass_from_normal_volume`, `mass_to_actual_volume`, `mass_from_actual_volume`, `actual_volume_to_normal_volume`, `normal_volume_to_actual_volume`.

## Why

This was the **last implicit physical identity** in the library. The same anti-pattern was already removed from `encomp.coolprop.fluid` (which requires `name=`) and `convert_volume_mass` (which requires a density), and `AGENTS.md` states the invariant — `encomp.gases` was the standing exception, flagged by the 1.9.2 holistic review as "an inconsistency of concept".

A guessed fluid does not fail loudly: it returns plausible numbers for the *wrong gas*. `mass_to_normal_volume(Q(1, "kg"))` silently answered for air even when the caller meant methane (a ~1.8× difference), which is precisely why the identity may not be defaulted.

**Keyword-only** rather than positional-with-no-default because a required parameter cannot follow the defaulted `condition_*` arguments — and it matches the `cp.fluid(..., name=...)` spelling. It also means the name can never land in a condition parameter by position.

## Notes

- Released as a **patch** (1.9.4): per `README.md`, encomp does not follow strict semantic versioning, and breaking changes are called out in the release notes instead.
- `AGENTS.md` now records that no exceptions to the invariant remain, so the next review doesn't re-flag it.
- No docs or README examples called these functions; only the test suite needed updating, plus a new test pinning that the argument is required and keyword-only, and that naming a different gas changes the answer.

## Gates

pytest 1190 passed · pyright 0 errors · pyrefly 0 errors · ty clean · ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)