### PR TITLE
Defer unsupported Quantity arithmetic operands

### DIFF
--- a/encomp/tests/test_static_typing.py
+++ b/encomp/tests/test_static_typing.py
@@ -61,6 +61,33 @@ from encomp.units import Quantity as Q
 q = Q(1, Q(2, "m"))
 """
 
+_VALID_REFLECTED_ARITHMETIC = """
+from typing import Any, assert_type
+
+from encomp.units import Quantity as Q
+
+class Expression:
+    def __radd__(self, other: Q[Any, Any]) -> "Expression":
+        return self
+
+    def __rsub__(self, other: Q[Any, Any]) -> "Expression":
+        return self
+
+    def __rmul__(self, other: Q[Any, Any]) -> "Expression":
+        return self
+
+    def __rtruediv__(self, other: Q[Any, Any]) -> "Expression":
+        return self
+
+quantity = Q(2.0, "m")
+expression = Expression()
+
+assert_type(quantity + expression, Expression)
+assert_type(quantity - expression, Expression)
+assert_type(quantity * expression, Expression)
+assert_type(quantity / expression, Expression)
+"""
+
 _VALID_QUANTITY_FRAME = """
 import polars as pl
 
@@ -187,6 +214,28 @@ def test_quantity_unit_rejected_by_ty(tmp_path: Path) -> None:
 def test_quantity_unit_rejected_at_runtime() -> None:
     with pytest.raises(TypeError, match="got Quantity"):
         Q(1, cast(Any, Q(2, "m")))
+
+
+@pytest.mark.skipif(_PYREFLY is None, reason="pyrefly not installed")
+@pytest.mark.skipif(_ROOT is None, reason=_NO_CONFIG)
+def test_reflected_arithmetic_accepted_by_pyrefly(tmp_path: Path) -> None:
+    assert _PYREFLY is not None and _ROOT is not None
+    cmd = [_PYREFLY, "check", "--config", str(_ROOT / "pyproject.toml")]
+    assert _check(cmd, _VALID_REFLECTED_ARITHMETIC, tmp_path) == 0
+
+
+@pytest.mark.skipif(_PYRIGHT is None, reason="pyright not installed")
+@pytest.mark.skipif(_ROOT is None, reason=_NO_CONFIG)
+def test_reflected_arithmetic_accepted_by_pyright(tmp_path: Path) -> None:
+    assert _PYRIGHT is not None
+    assert _check([_PYRIGHT], _VALID_REFLECTED_ARITHMETIC, tmp_path) == 0
+
+
+@pytest.mark.skipif(_TY is None, reason="ty not installed")
+@pytest.mark.skipif(_ROOT is None, reason=_NO_CONFIG)
+def test_reflected_arithmetic_accepted_by_ty(tmp_path: Path) -> None:
+    assert _TY is not None
+    assert _check([_TY, "check"], _VALID_REFLECTED_ARITHMETIC, tmp_path) == 0
 
 
 @pytest.mark.skipif(_PYREFLY is None, reason="pyrefly not installed")

--- a/encomp/tests/test_units.py
+++ b/encomp/tests/test_units.py
@@ -1186,6 +1186,35 @@ def test_convert_volume_mass() -> None:
     assert m.check(MassFlow)
 
 
+def test_arithmetic_defers_to_unknown_operand_reflected_methods() -> None:
+    class ReflectedArithmetic:
+        def __radd__(self, other: object) -> tuple[str, object]:
+            return ("radd", other)
+
+        def __rsub__(self, other: object) -> tuple[str, object]:
+            return ("rsub", other)
+
+        def __rmul__(self, other: object) -> tuple[str, object]:
+            return ("rmul", other)
+
+        def __rtruediv__(self, other: object) -> tuple[str, object]:
+            return ("rtruediv", other)
+
+    quantity = Q(2.0, "m")
+    operand = ReflectedArithmetic()
+
+    assert quantity + operand == ("radd", quantity)
+    assert quantity - operand == ("rsub", quantity)
+    assert quantity * operand == ("rmul", quantity)
+    assert quantity / operand == ("rtruediv", quantity)
+
+    unsupported = object()
+    assert cast(Any, quantity).__add__(unsupported) is NotImplemented
+    assert cast(Any, quantity).__sub__(unsupported) is NotImplemented
+    assert cast(Any, quantity).__mul__(unsupported) is NotImplemented
+    assert cast(Any, quantity).__truediv__(unsupported) is NotImplemented
+
+
 def test_compatibility() -> None:
     _ = Q(1) + Q(2)
 

--- a/encomp/units.py
+++ b/encomp/units.py
@@ -19,7 +19,7 @@ import sys
 import warnings
 from collections.abc import Iterable, Iterator, Sequence, Sized
 from inspect import isclass
-from types import UnionType
+from types import NotImplementedType, UnionType
 from typing import (
     TYPE_CHECKING,
     Annotated,
@@ -668,6 +668,27 @@ class Quantity(
             return
 
         raise TypeError(f"Invalid magnitude type: {mt}, expected one of float, np.ndarray, pl.Series, pl.Expr")
+
+    @staticmethod
+    def _is_supported_arithmetic_operand(value: object) -> bool:
+        """Whether ``value`` belongs to the closed set handled directly by arithmetic.
+
+        An unrecognized object must be left to its reflected operator rather than being
+        passed through pint as a possible magnitude. The latter can either obscure pint's
+        ``NotImplemented`` result or make pint perform magnitude arithmetic first and then
+        attempt to construct a ``Quantity`` with an unsupported magnitude type.
+
+        This is deliberately a type check rather than a call to ``_validate_magnitude``:
+        validation can allocate and traverse a container, and invalid values of a supported
+        type must continue to raise their specific validation error.
+        """
+
+        return (
+            isinstance(value, (Quantity, Unit, numbers.Real, np.ndarray, pl.Series, pl.Expr, Sequence))
+            # SymPy is imported lazily, so use the same protocol check as
+            # _validate_magnitude to preserve symbolic arithmetic.
+            or hasattr(value, "is_Atom")
+        )
 
     @staticmethod
     def _get_magnitude_type_name(mt: object) -> MagnitudeTypeName:
@@ -2418,7 +2439,11 @@ class Quantity(
     def __add__(self, other: Quantity[DT, float]) -> Quantity[DT, MT]: ...
     @overload
     def __add__(self: Quantity[DT, float], other: Quantity[DT, MT_]) -> Quantity[DT, MT_]: ...
-    def __add__(self, other: Quantity[Any, Any] | float) -> Quantity[Any, Any]:
+    def __add__(self, other: object) -> Quantity[Any, Any] | NotImplementedType:
+        if not self._is_supported_arithmetic_operand(other):
+            return NotImplemented
+
+        other = cast("Quantity[Any, Any] | float", other)
         if isinstance(other, Quantity):
             self._check_comparable_magnitudes(self.m, other.m, "combine")  # ty: ignore[invalid-argument-type]
         try:
@@ -2435,8 +2460,11 @@ class Quantity(
 
             raise e
 
-        ret = cast("Quantity[DT, MT]", self._pint_super.__add__(other))
+        ret = self._pint_super.__add__(other)
+        if ret is NotImplemented:
+            return NotImplemented
 
+        ret = cast("Quantity[DT, MT]", ret)
         return self._call_subclass(ret.m, ret.u)
 
     def __iadd__(self, other: Any) -> Any:  # noqa: ANN401
@@ -2478,7 +2506,11 @@ class Quantity(
     def __sub__(self, other: Quantity[DT, float]) -> Quantity[DT, MT]: ...
     @overload
     def __sub__(self: Quantity[DT, float], other: Quantity[DT, MT_]) -> Quantity[DT, MT_]: ...
-    def __sub__(self, other: Quantity[Any, Any] | float) -> Quantity[Any, Any]:
+    def __sub__(self, other: object) -> Quantity[Any, Any] | NotImplementedType:
+        if not self._is_supported_arithmetic_operand(other):
+            return NotImplemented
+
+        other = cast("Quantity[Any, Any] | float", other)
         if isinstance(other, Quantity):
             self._check_comparable_magnitudes(self.m, other.m, "combine")  # ty: ignore[invalid-argument-type]
         try:
@@ -2494,8 +2526,11 @@ class Quantity(
 
             raise e
 
-        ret = cast("Quantity[DT, MT]", self._pint_super.__sub__(other))
+        ret = self._pint_super.__sub__(other)
+        if ret is NotImplemented:
+            return NotImplemented
 
+        ret = cast("Quantity[DT, MT]", ret)
         if (
             isinstance(other, Quantity)
             and issubclass(self.dt, Temperature)
@@ -3312,11 +3347,18 @@ class Quantity(
     def __mul__(self, other: Quantity[DT_, float]) -> Quantity[UnknownDimensionality, MT]: ...
     @overload
     def __mul__(self, other: Quantity[DT_, MT]) -> Quantity[UnknownDimensionality, MT]: ...
-    def __mul__(self, other: Quantity[Any, Any] | float) -> Quantity[Any, Any]:
+    def __mul__(self, other: object) -> Quantity[Any, Any] | NotImplementedType:
+        if not self._is_supported_arithmetic_operand(other):
+            return NotImplemented
+
+        other = cast("Quantity[Any, Any] | float", other)
         if isinstance(other, Quantity):
             self._check_comparable_magnitudes(self.m, other.m, "combine")  # ty: ignore[invalid-argument-type]
-        ret = cast("Quantity[DT, MT]", self._pint_super.__mul__(other))
+        ret = self._pint_super.__mul__(other)
+        if ret is NotImplemented:
+            return NotImplemented
 
+        ret = cast("Quantity[DT, MT]", ret)
         # preserve the dimensionality for other
         # it might be a distinct subclass with identical units as another dimensionality
         # NOTE: isinstance first, and self.u.dimensionless rather than self.dimensionless:
@@ -3787,7 +3829,11 @@ class Quantity(
     def __truediv__(self, other: Quantity[DT_, float]) -> Quantity[UnknownDimensionality, MT]: ...
     @overload
     def __truediv__(self, other: Quantity[DT_, MT]) -> Quantity[UnknownDimensionality, MT]: ...
-    def __truediv__(self, other: Quantity[Any, Any] | float) -> Quantity[Any, Any]:
+    def __truediv__(self, other: object) -> Quantity[Any, Any] | NotImplementedType:
+        if not self._is_supported_arithmetic_operand(other):
+            return NotImplemented
+
+        other = cast("Quantity[Any, Any] | float", other)
         if isinstance(other, Quantity):
             self._check_comparable_magnitudes(self.m, other.m, "combine")  # ty: ignore[invalid-argument-type]
 
@@ -3797,8 +3843,11 @@ class Quantity(
         # magnitudes yield IEEE ±inf / nan elementwise (numpy warns, polars is silent).
         # Normalizing either way would mean lying about one container to match the other;
         # pinned by test_division_by_zero_follows_the_container
-        ret = cast("Quantity[DT, MT]", self._pint_super.__truediv__(other))
+        ret = self._pint_super.__truediv__(other)
+        if ret is NotImplemented:
+            return NotImplemented
 
+        ret = cast("Quantity[DT, MT]", ret)
         # preserve the dimensionality for other
         # it might be a distinct subclass with identical units as another dimensionality
         # (see __mul__ for why this is a unit-level check with isinstance first)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "encomp"
-version = "1.9.4"
+version = "1.9.5"
 description = "General-purpose library for engineering computations"
 authors = [{ name = "William Laurén", email = "lauren.william.a@gmail.com" }]
 requires-python = ">=3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -514,7 +514,7 @@ wheels = [
 
 [[package]]
 name = "encomp"
-version = "1.9.4"
+version = "1.9.5"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },


### PR DESCRIPTION
## Summary

- return `NotImplemented` for unsupported `Quantity` operands across `+`, `-`, `*`, and `/`
- preserve validation for supported numeric, container, unit, and symbolic operands
- add runtime and Pyright/Pyrefly/ty coverage for reflected arithmetic
- bump the package version to 1.9.5

## Verification

- `uv run --no-project ruff check .`
- `uv run --no-project ruff format --check .`
- `uv run --no-project pyright`
- `uv run --no-project pyrefly check`
- `uv run --no-project ty check`
- `uv run --no-project pytest -q` — 1094 passed, 2 skipped